### PR TITLE
disable network check

### DIFF
--- a/packages/files-ui/src/App.tsx
+++ b/packages/files-ui/src/App.tsx
@@ -73,7 +73,6 @@ const App: React.FC<{}> = () => {
           <CssBaseline />
           <ToasterProvider autoDismiss>
             <Web3Provider
-              networkIds={[1]}
               onboardConfig={{
                 walletSelect: {
                   wallets: [
@@ -97,6 +96,7 @@ const App: React.FC<{}> = () => {
                   ],
                 },
               }}
+              checkNetwork={false}
             >
               <ImployApiProvider apiUrl={apiUrl}>
                 <UserProvider>


### PR DESCRIPTION
This PR disables the mainnet network check when signing a message.

@RyRy79261 this will impact the crypto payment part of the equation. You just need to run a check on the value of {network} from useWeb3() and display the appropriate error message if the network does not match the approved.