### PR TITLE
Fix dark mode buttons color for missing shares modal

### DIFF
--- a/packages/files-ui/src/Components/Modules/LoginModule/MissingShares.tsx
+++ b/packages/files-ui/src/Components/Modules/LoginModule/MissingShares.tsx
@@ -29,15 +29,7 @@ const useStyles = makeStyles(({ breakpoints, constants, palette }: CSFTheme) =>
       width: `calc(100% - ${constants.generalUnit * 8}px)`,
       marginLeft: constants.generalUnit * 4,
       marginRight: constants.generalUnit * 4,
-      marginBottom: constants.generalUnit * 2,
-      [breakpoints.up("md")]: {
-        backgroundColor: palette.common.black.main,
-        color: palette.common.white.main
-      },
-      [breakpoints.down("md")]: {
-        backgroundColor: palette.common.black.main,
-        color: palette.common.white.main
-      }
+      marginBottom: constants.generalUnit * 2
     },
     buttonWrapper: {
       display: "flex",


### PR DESCRIPTION
closes #859

Looking good again, both in dark and light
![image](https://user-images.githubusercontent.com/33178835/113131546-a4b58b00-921d-11eb-9d4c-b7a461f29811.png)
![image](https://user-images.githubusercontent.com/33178835/113131588-b303a700-921d-11eb-8c08-3cc9abcfbc7e.png)
