### PR TITLE
Home button navigation

### DIFF
--- a/packages/files-ui/src/Components/Layouts/AppNav.tsx
+++ b/packages/files-ui/src/Components/Layouts/AppNav.tsx
@@ -215,7 +215,7 @@ const AppNav: React.FC<IAppNav> = ({ navOpen, setNavOpen }: IAppNav) => {
   const { desktop, setTheme, themeKey } = useThemeSwitcher()
   const classes = useStyles()
 
-  const { spaceUsed } = useDrive()
+  const { spaceUsed, updateCurrentPath } = useDrive()
 
   const { isLoggedIn, secured } = useImployApi()
   const { publicKey, isNewDevice, shouldInitializeAccount, logout } = useThresholdKey()
@@ -231,7 +231,8 @@ const AppNav: React.FC<IAppNav> = ({ navOpen, setNavOpen }: IAppNav) => {
     if (!desktop && navOpen) {
       setNavOpen(false)
     }
-  }, [desktop, navOpen, setNavOpen])
+    updateCurrentPath("/", "csf", true)
+  }, [desktop, navOpen, setNavOpen, updateCurrentPath])
 
   const collectFeedback = () => {
     window.open("https://forms.gle/FefqZRD3fDVYyarC8", "_blank")


### PR DESCRIPTION
closes #885 

Note: Clicking on Home button or the Home breadcrumb, reloads the "/" path content even if they are already there.
While this is fine for now, it may be logged as a new issue for when we refactor DriveContext.