### PR TITLE
Refactor file deletion

### DIFF
--- a/packages/files-ui/src/Components/Modules/FileBrowsers/BinFileBrowser.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/BinFileBrowser.tsx
@@ -9,10 +9,7 @@ import { IFilesTableBrowserProps } from "../../Modules/FileBrowsers/types"
 
 const BinFileBrowser: React.FC<IFilesBrowserModuleProps> = ({ controls = false }: IFilesBrowserModuleProps) => {
   const {
-    deleteFile,
     updateCurrentPath,
-    pathContents,
-    loadingCurrentPath,
     bucketType,
     recoverFile
   } = useDrive()
@@ -41,10 +38,7 @@ const BinFileBrowser: React.FC<IFilesBrowserModuleProps> = ({ controls = false }
       <FilesTableView
         crumbs={undefined}
         recoverFile={handleRecover}
-        deleteFile={deleteFile}
-        loadingCurrentPath={loadingCurrentPath}
         showUploadsInTable={false}
-        sourceFiles={pathContents}
         updateCurrentPath={updateCurrentPath}
         heading={t`Bin`}
         controls={controls}

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/CSFFileBrowser.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/CSFFileBrowser.tsx
@@ -11,17 +11,11 @@ import { t } from "@lingui/macro"
 
 const CSFFileBrowser: React.FC<IFilesBrowserModuleProps> = ({ controls = true }: IFilesBrowserModuleProps) => {
   const {
-    moveFileToTrash,
-    bulkMoveFileToTrash,
-    downloadFile,
     renameFile,
     moveFile,
     currentPath,
     updateCurrentPath,
-    pathContents,
     uploadFiles,
-    uploadsInProgress,
-    loadingCurrentPath,
     bucketType
   } = useDrive()
 
@@ -103,16 +97,10 @@ const CSFFileBrowser: React.FC<IFilesBrowserModuleProps> = ({ controls = true }:
         bulkOperations={bulkOperations}
         crumbs={crumbs}
         currentPath={currentPath}
-        deleteFile={moveFileToTrash}
-        bulkMoveFileToTrash={bulkMoveFileToTrash}
-        downloadFile={downloadFile}
         handleMove={handleMove}
         handleRename={handleRename}
         handleUploadOnDrop={handleUploadOnDrop}
-        uploadsInProgress={uploadsInProgress}
-        loadingCurrentPath={loadingCurrentPath}
         showUploadsInTable={true}
-        sourceFiles={pathContents}
         updateCurrentPath={updateCurrentPath}
         heading = {t`My Files`}
         controls={controls}

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/MoveFileModal.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/MoveFileModal.tsx
@@ -193,7 +193,7 @@ const MoveFileModule: React.FC<IMoveFileModuleProps> = ({
                 commonIcon={<FolderIcon />}
                 selectedId={movePath}
                 onSelectNode={(path: string) => setMovePath(path)}
-              /> : <Typography>No folders</Typography>
+              /> : <Typography><Trans>No folders</Trans></Typography>
             }
           </div>
         </ScrollbarWrapper>

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/MoveFileModal.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/MoveFileModal.tsx
@@ -187,12 +187,14 @@ const MoveFileModule: React.FC<IMoveFileModuleProps> = ({
       <Grid item xs={12} sm={12} className={classes.treeContainer}>
         <ScrollbarWrapper autoHide={true} maxHeight={200}>
           <div className={classes.treeScrollView}>
-            <TreeView
-              treeData={folderTree}
-              commonIcon={<FolderIcon />}
-              selectedId={movePath}
-              onSelectNode={(path: string) => setMovePath(path)}
-            />
+            {folderTree.length ?
+              <TreeView
+                treeData={folderTree}
+                commonIcon={<FolderIcon />}
+                selectedId={movePath}
+                onSelectNode={(path: string) => setMovePath(path)}
+              /> : <Typography>No folders</Typography>
+            }
           </div>
         </ScrollbarWrapper>
       </Grid>

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/SearchFileBrowser.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/SearchFileBrowser.tsx
@@ -75,7 +75,7 @@ const SearchFileBrowser: React.FC<IFilesBrowserModuleProps> = ({ controls = fals
     <DragAndDrop>
       <FilesTableView
         crumbs={undefined}
-        loadingCurrentPath={loadingSearchResults}
+        loadingSearchResults={loadingSearchResults}
         showUploadsInTable={false}
         viewFolder={viewFolder}
         sourceFiles={pathContents}

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/types.ts
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/types.ts
@@ -1,8 +1,7 @@
 import { Crumb } from "@chainsafe/common-components"
 import {
   FileSystemItem,
-  BucketType,
-  UploadProgress
+  BucketType
 } from "../../../Contexts/DriveContext"
 
 export type FileOperation =
@@ -33,9 +32,6 @@ export interface IFilesTableBrowserProps
   bulkOperations?: IBulkOperations
   handleRename?: (path: string, new_path: string) => Promise<void>
   handleMove?: (path: string, new_path: string) => Promise<void>
-  downloadFile?: (cid: string) => Promise<void>
-  deleteFile?: (cid: string) => Promise<void>
-  bulkMoveFileToTrash?: (cids: string[]) => Promise<void>
   recoverFile?: (cid: string) => Promise<void>
   viewFolder?: (cid: string) => void
   allowDropUpload?: boolean
@@ -51,11 +47,10 @@ export interface IFilesTableBrowserProps
     newBucketType?: BucketType,
     showLoading?: boolean,
   ) => void
-  loadingCurrentPath: boolean
-  uploadsInProgress?: UploadProgress[]
+  loadingSearchResults?: boolean
   showUploadsInTable: boolean
 
-  sourceFiles: FileSystemItem[]
+  sourceFiles?: FileSystemItem[]
   currentPath?: string
   crumbs: Crumb[] | undefined
   getPath?: (cid: string) => string | undefined

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx
@@ -231,6 +231,9 @@ const useStyles = makeStyles(
         "& > *": {
           marginRight: constants.generalUnit
         }
+      },
+      confirmDeletionDialog: {
+        top: "50%"
       }
     })
   }
@@ -791,6 +794,8 @@ const FilesTableView = ({
         rejectText = {t`Cancel`}
         acceptText = {t`Confirm`}
         acceptButtonProps={{ loading: isDeletingFiles, disabled: isDeletingFiles }}
+        rejectButtonProps={{ disabled: isDeletingFiles }}
+        injectedClass={{ inner: classes.confirmDeletionDialog }}
       />
       <UploadProgressModals />
       <DownloadProgressModals />

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx
@@ -499,11 +499,13 @@ const FilesTableView: React.FC<IFilesTableBrowserProps> = ({
   const handleBulkMoveToTrash = useCallback(async () => {
     if (bulkMoveFileToTrash) {
       setIsDeletingFiles(true)
-      bulkMoveFileToTrash(selected).catch(console.error).finally(() => {
-        setIsDeletingFiles(false)
-        setSelected([])
-        setDeleteDialog(undefined)
-      })
+      bulkMoveFileToTrash(selected)
+        .catch(console.error)
+        .finally(() => {
+          setIsDeletingFiles(false)
+          setSelected([])
+          setDeleteDialog(undefined)
+        })
     }
   }, [selected, bulkMoveFileToTrash, setSelected])
 

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx
@@ -433,7 +433,7 @@ const FilesTableView: React.FC<IFilesTableBrowserProps> = ({
   const [moveFileData, setMoveFileData] = useState<
     { modal: boolean; fileData: FileSystemItem | FileSystemItem[] } | undefined
   >(undefined)
-  const [deleteDialogOpen, setDeleteDialog] = useState<() => void | undefined>()
+  const [deleteHandler, setDeleteHandler] = useState<() => void | undefined>()
   const [isDeletingFiles, setIsDeletingFiles] = useState(false)
   const [fileInfoPath, setFileInfoPath] = useState<string | undefined>(
     undefined
@@ -504,7 +504,7 @@ const FilesTableView: React.FC<IFilesTableBrowserProps> = ({
         .finally(() => {
           setIsDeletingFiles(false)
           setSelected([])
-          setDeleteDialog(undefined)
+          setDeleteHandler(undefined)
         })
     }
   }, [selected, bulkMoveFileToTrash, setSelected])
@@ -516,7 +516,7 @@ const FilesTableView: React.FC<IFilesTableBrowserProps> = ({
         .catch(console.error)
         .finally(() => {
           setIsDeletingFiles(false)
-          setDeleteDialog(undefined)
+          setDeleteHandler(undefined)
         })
     }
   }, [deleteFile])
@@ -654,7 +654,7 @@ const FilesTableView: React.FC<IFilesTableBrowserProps> = ({
           {validBulkOps.indexOf("delete") >= 0 && (
             <Button
               onClick={() =>
-                setDeleteDialog(() => () => {
+                setDeleteHandler(() => () => {
                   handleBulkMoveToTrash()
                 })
               }
@@ -793,7 +793,7 @@ const FilesTableView: React.FC<IFilesTableBrowserProps> = ({
                   }}
                   handleMove={handleMove}
                   deleteFile={(cid: string) =>
-                    setDeleteDialog(() => () => {
+                    setDeleteHandler(() => () => {
                       handleDeleteFile(cid)
                     })
                   }
@@ -822,9 +822,9 @@ const FilesTableView: React.FC<IFilesTableBrowserProps> = ({
         />
       )}
       <Dialog
-        active={deleteDialogOpen !== undefined}
-        reject={() => setDeleteDialog(undefined)}
-        accept={() => deleteDialogOpen && deleteDialogOpen()}
+        active={deleteHandler !== undefined}
+        reject={() => setDeleteHandler(undefined)}
+        accept={() => deleteHandler && deleteHandler()}
         requestMessage={t`Are you sure you wish to delete?`}
         rejectText = {t`Cancel`}
         acceptText = {t`Confirm`}

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx
@@ -512,10 +512,12 @@ const FilesTableView: React.FC<IFilesTableBrowserProps> = ({
   const handleDeleteFile = useCallback((cid: string) => {
     if (deleteFile) {
       setIsDeletingFiles(true)
-      deleteFile(cid).catch(console.error).finally(() => {
-        setIsDeletingFiles(false)
-        setDeleteDialog(undefined)
-      })
+      deleteFile(cid)
+        .catch(console.error)
+        .finally(() => {
+          setIsDeletingFiles(false)
+          setDeleteDialog(undefined)
+        })
     }
   }, [deleteFile])
 

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx
@@ -433,7 +433,7 @@ const FilesTableView: React.FC<IFilesTableBrowserProps> = ({
   const [moveFileData, setMoveFileData] = useState<
     { modal: boolean; fileData: FileSystemItem | FileSystemItem[] } | undefined
   >(undefined)
-  const [deleteDialogOpen, setDeleteDialog] = useState<() => Promise<void> | undefined>()
+  const [deleteDialogOpen, setDeleteDialog] = useState<() => void | undefined>()
   const [isDeletingFiles, setIsDeletingFiles] = useState(false)
   const [fileInfoPath, setFileInfoPath] = useState<string | undefined>(
     undefined
@@ -496,7 +496,7 @@ const FilesTableView: React.FC<IFilesTableBrowserProps> = ({
     }
   }, [selected, items, bulkOperations])
 
-  const handleBulkMoveToTrash = useCallback(async () => {
+  const handleBulkMoveToTrash = useCallback(() => {
     if (bulkMoveFileToTrash) {
       setIsDeletingFiles(true)
       bulkMoveFileToTrash(selected)
@@ -509,7 +509,7 @@ const FilesTableView: React.FC<IFilesTableBrowserProps> = ({
     }
   }, [selected, bulkMoveFileToTrash, setSelected])
 
-  const handleDeleteFile = useCallback(async (cid: string) => {
+  const handleDeleteFile = useCallback((cid: string) => {
     if (deleteFile) {
       setIsDeletingFiles(true)
       deleteFile(cid).catch(console.error).finally(() => {
@@ -652,7 +652,7 @@ const FilesTableView: React.FC<IFilesTableBrowserProps> = ({
           {validBulkOps.indexOf("delete") >= 0 && (
             <Button
               onClick={() =>
-                setDeleteDialog(() => async () => {
+                setDeleteDialog(() => () => {
                   handleBulkMoveToTrash()
                 })
               }
@@ -791,7 +791,7 @@ const FilesTableView: React.FC<IFilesTableBrowserProps> = ({
                   }}
                   handleMove={handleMove}
                   deleteFile={(cid: string) =>
-                    setDeleteDialog(() => async () => {
+                    setDeleteDialog(() => () => {
                       handleDeleteFile(cid)
                     })
                   }

--- a/packages/files-ui/src/locales/en/messages.po
+++ b/packages/files-ui/src/locales/en/messages.po
@@ -53,10 +53,6 @@ msgstr "Add sign-in methods"
 msgid "Approve"
 msgstr "Approve"
 
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:563
-msgid "Are you sure you wish to delete?"
-msgstr "Are you sure you wish to delete?"
-
 #: src/Components/Modules/LoginModule/ConfirmSkip.tsx:57
 msgid "Are you sure?"
 msgstr "Are you sure?"
@@ -96,8 +92,8 @@ msgstr "CID (Content Identifier)"
 
 #: src/Components/Modules/CreateFolderModule.tsx:122
 #: src/Components/Modules/FileBrowsers/MoveFileModal.tsx:153
-#: src/Components/Modules/FileBrowsers/views/FileSystemItemRow.tsx:341
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:563
+#: src/Components/Modules/FileBrowsers/views/FileSystemItemRow.tsx:348
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:544
 #: src/Components/Modules/UploadFileModule.tsx:115
 msgid "Cancel"
 msgstr "Cancel"
@@ -126,7 +122,7 @@ msgstr "Close"
 msgid "Complete"
 msgstr "Complete"
 
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:563
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:544
 msgid "Confirm"
 msgstr "Confirm"
 
@@ -196,7 +192,7 @@ msgstr "Create"
 msgid "Create Folder"
 msgstr "Create Folder"
 
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:479
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:461
 msgid "Create folder"
 msgstr "Create folder"
 
@@ -213,11 +209,11 @@ msgstr "Date uploaded"
 msgid "Decryption failed"
 msgstr "Decryption failed"
 
-#: src/Components/Modules/FileBrowsers/views/FileSystemItemRow.tsx:172
+#: src/Components/Modules/FileBrowsers/views/FileSystemItemRow.tsx:179
 msgid "Delete"
 msgstr "Delete"
 
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:505
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:485
 msgid "Delete selected"
 msgstr "Delete selected"
 
@@ -225,7 +221,7 @@ msgstr "Delete selected"
 msgid "Device awaiting confirmation"
 msgstr "Device awaiting confirmation"
 
-#: src/Components/Modules/FileBrowsers/views/FileSystemItemRow.tsx:181
+#: src/Components/Modules/FileBrowsers/views/FileSystemItemRow.tsx:188
 #: src/Components/Modules/FilePreviewModal.tsx:294
 #: src/Components/Modules/FilePreviewModal.tsx:329
 msgid "Download"
@@ -239,7 +235,7 @@ msgstr "Download complete"
 msgid "Download recovery key"
 msgstr "Download recovery key"
 
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:446
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:428
 msgid "Drop to upload files"
 msgstr "Drop to upload files"
 
@@ -282,9 +278,9 @@ msgstr ""
 "If you are using a contract wallet, please make \n"
 "sure you have activated your wallet."
 
-#: src/Contexts/DriveContext.tsx:358
-#: src/Contexts/DriveContext.tsx:387
-#: src/Contexts/DriveContext.tsx:424
+#: src/Contexts/DriveContext.tsx:360
+#: src/Contexts/DriveContext.tsx:391
+#: src/Contexts/DriveContext.tsx:427
 msgid "File"
 msgstr "File"
 
@@ -316,9 +312,9 @@ msgstr "Files"
 msgid "Files uses device backups to save your browser."
 msgstr "Files uses device backups to save your browser."
 
-#: src/Contexts/DriveContext.tsx:358
-#: src/Contexts/DriveContext.tsx:387
-#: src/Contexts/DriveContext.tsx:424
+#: src/Contexts/DriveContext.tsx:360
+#: src/Contexts/DriveContext.tsx:391
+#: src/Contexts/DriveContext.tsx:427
 msgid "Folder"
 msgstr "Folder"
 
@@ -381,7 +377,7 @@ msgstr "Hold on, we are logging you in..."
 msgid "Home"
 msgstr "Home"
 
-#: src/Components/Modules/FileBrowsers/views/FileSystemItemRow.tsx:208
+#: src/Components/Modules/FileBrowsers/views/FileSystemItemRow.tsx:215
 msgid "Info"
 msgstr "Info"
 
@@ -437,11 +433,11 @@ msgid "Looks like you’re signing in from a new browser. Please choose one of t
 msgstr "Looks like you’re signing in from a new browser. Please choose one of the following to continue:"
 
 #: src/Components/Modules/FileBrowsers/MoveFileModal.tsx:156
-#: src/Components/Modules/FileBrowsers/views/FileSystemItemRow.tsx:190
+#: src/Components/Modules/FileBrowsers/views/FileSystemItemRow.tsx:197
 msgid "Move"
 msgstr "Move"
 
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:500
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:482
 msgid "Move selected"
 msgstr "Move selected"
 
@@ -453,11 +449,11 @@ msgstr "Move to..."
 msgid "My Files"
 msgstr "My Files"
 
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:530
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:510
 msgid "Name"
 msgstr "Name"
 
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:461
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:443
 msgid "New folder"
 msgstr "New folder"
 
@@ -470,7 +466,7 @@ msgstr "Next"
 msgid "Nice to see you again!"
 msgstr "Nice to see you again!"
 
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:518
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:498
 msgid "No files to show"
 msgstr "No files to show"
 
@@ -494,7 +490,7 @@ msgstr "Number of copies (Replication Factor)"
 msgid "OK"
 msgstr "OK"
 
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:511
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:491
 msgid "One sec, getting files ready..."
 msgstr "One sec, getting files ready..."
 
@@ -543,7 +539,7 @@ msgstr "Passwords must match"
 msgid "Please provide a password"
 msgstr "Please provide a password"
 
-#: src/Components/Modules/FileBrowsers/views/FileSystemItemRow.tsx:226
+#: src/Components/Modules/FileBrowsers/views/FileSystemItemRow.tsx:233
 msgid "Preview"
 msgstr "Preview"
 
@@ -573,7 +569,7 @@ msgstr "Profile and Display"
 msgid "Profile updated"
 msgstr "Profile updated"
 
-#: src/Components/Modules/FileBrowsers/views/FileSystemItemRow.tsx:217
+#: src/Components/Modules/FileBrowsers/views/FileSystemItemRow.tsx:224
 msgid "Recover"
 msgstr "Recover"
 
@@ -593,11 +589,11 @@ msgstr "Reject all"
 msgid "Remind me later"
 msgstr "Remind me later"
 
-#: src/Components/Modules/FileBrowsers/views/FileSystemItemRow.tsx:163
+#: src/Components/Modules/FileBrowsers/views/FileSystemItemRow.tsx:170
 msgid "Rename"
 msgstr "Rename"
 
-#: src/Components/Modules/FileBrowsers/views/FileSystemItemRow.tsx:336
+#: src/Components/Modules/FileBrowsers/views/FileSystemItemRow.tsx:343
 msgid "Rename File/Folder"
 msgstr "Rename File/Folder"
 
@@ -709,7 +705,7 @@ msgstr "Setting up multiple sign-in methods makes signing in on multiple devices
 msgid "Settings"
 msgstr "Settings"
 
-#: src/Components/Modules/FileBrowsers/views/FileSystemItemRow.tsx:199
+#: src/Components/Modules/FileBrowsers/views/FileSystemItemRow.tsx:206
 msgid "Share"
 msgstr "Share"
 
@@ -732,7 +728,7 @@ msgstr "Sign in with a different account"
 msgid "Sign-in methods"
 msgstr "Sign-in methods"
 
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:534
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:514
 msgid "Size"
 msgstr "Size"
 
@@ -790,8 +786,8 @@ msgstr "There was an error connecting your wallet"
 msgid "There was an error creating this folder"
 msgstr "There was an error creating this folder"
 
-#: src/Contexts/DriveContext.tsx:366
-#: src/Contexts/DriveContext.tsx:395
+#: src/Contexts/DriveContext.tsx:368
+#: src/Contexts/DriveContext.tsx:399
 msgid "There was an error deleting this"
 msgstr "There was an error deleting this"
 
@@ -803,7 +799,7 @@ msgstr "There was an error getting file info"
 msgid "There was an error getting folder info"
 msgstr "There was an error getting folder info"
 
-#: src/Contexts/DriveContext.tsx:563
+#: src/Contexts/DriveContext.tsx:566
 msgid "There was an error getting search results"
 msgstr "There was an error getting search results"
 
@@ -815,7 +811,7 @@ msgstr "There was an error getting the preview."
 msgid "There was an error moving this file"
 msgstr "There was an error moving this file"
 
-#: src/Contexts/DriveContext.tsx:432
+#: src/Contexts/DriveContext.tsx:435
 msgid "There was an error recovering this"
 msgstr "There was an error recovering this"
 
@@ -831,12 +827,12 @@ msgstr "Try again"
 msgid "Try another method"
 msgstr "Try another method"
 
-#: src/Components/Modules/FileBrowsers/views/FileSystemItemRow.tsx:344
+#: src/Components/Modules/FileBrowsers/views/FileSystemItemRow.tsx:351
 msgid "Update"
 msgstr "Update"
 
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:467
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:487
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:449
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:469
 msgid "Upload"
 msgstr "Upload"
 
@@ -848,7 +844,7 @@ msgstr "Upload complete"
 msgid "Use a different login method"
 msgstr "Use a different login method"
 
-#: src/Components/Modules/FileBrowsers/views/FileSystemItemRow.tsx:235
+#: src/Components/Modules/FileBrowsers/views/FileSystemItemRow.tsx:242
 msgid "View folder"
 msgstr "View folder"
 
@@ -880,6 +876,10 @@ msgstr "Yes I understand"
 msgid "Yes, save it"
 msgstr "Yes, save it"
 
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:544
+msgid "You are about to delete {0} file(s)."
+msgstr "You are about to delete {0} file(s)."
+
 #: src/Components/Modules/LoginModule/PasswordSetup.tsx:60
 msgid "You can change this later."
 msgstr "You can change this later."
@@ -892,28 +892,24 @@ msgstr "You will need to sign a message in your wallet to complete sign in."
 msgid "Your recovery key can be used to restore your account in place of your backup phrase."
 msgstr "Your recovery key can be used to restore your account in place of your backup phrase."
 
-#: src/Components/Layouts/AppNav.tsx:227
-#~ msgid "beta"
-#~ msgstr "beta"
-
 #: src/Components/Modules/FileBrowsers/FileInfoModal.tsx:200
 msgid "copied !"
 msgstr "copied !"
 
-#: src/Contexts/DriveContext.tsx:358
-#: src/Contexts/DriveContext.tsx:387
+#: src/Contexts/DriveContext.tsx:360
+#: src/Contexts/DriveContext.tsx:391
 msgid "deleted successfully"
 msgstr "deleted successfully"
 
-#: src/Contexts/DriveContext.tsx:366
-#: src/Contexts/DriveContext.tsx:395
-#: src/Contexts/DriveContext.tsx:432
+#: src/Contexts/DriveContext.tsx:368
+#: src/Contexts/DriveContext.tsx:399
+#: src/Contexts/DriveContext.tsx:435
 msgid "file"
 msgstr "file"
 
-#: src/Contexts/DriveContext.tsx:366
-#: src/Contexts/DriveContext.tsx:395
-#: src/Contexts/DriveContext.tsx:432
+#: src/Contexts/DriveContext.tsx:368
+#: src/Contexts/DriveContext.tsx:399
+#: src/Contexts/DriveContext.tsx:435
 msgid "folder"
 msgstr "folder"
 
@@ -921,7 +917,7 @@ msgstr "folder"
 msgid "on"
 msgstr "on"
 
-#: src/Contexts/DriveContext.tsx:424
+#: src/Contexts/DriveContext.tsx:427
 msgid "recovered successfully"
 msgstr "recovered successfully"
 

--- a/packages/files-ui/src/locales/en/messages.po
+++ b/packages/files-ui/src/locales/en/messages.po
@@ -49,11 +49,11 @@ msgstr "Add more files"
 msgid "Add sign-in methods"
 msgstr "Add sign-in methods"
 
-#: src/Components/Elements/ShareTransferRequestModal.tsx:101
+#: src/Components/Elements/ShareTransferRequestModal.tsx:105
 msgid "Approve"
 msgstr "Approve"
 
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:544
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:563
 msgid "Are you sure you wish to delete?"
 msgstr "Are you sure you wish to delete?"
 
@@ -82,7 +82,7 @@ msgstr "Backup phrase saved"
 msgid "Bin"
 msgstr "Bin"
 
-#: src/Components/Modules/Settings/SavedBrowsers/BrowserPanel.tsx:112
+#: src/Components/Modules/Settings/SavedBrowsers/BrowserPanel.tsx:111
 msgid "Browser:"
 msgstr "Browser:"
 
@@ -95,9 +95,9 @@ msgid "CID (Content Identifier)"
 msgstr "CID (Content Identifier)"
 
 #: src/Components/Modules/CreateFolderModule.tsx:122
-#: src/Components/Modules/FileBrowsers/MoveFileModal.tsx:152
+#: src/Components/Modules/FileBrowsers/MoveFileModal.tsx:153
 #: src/Components/Modules/FileBrowsers/views/FileSystemItemRow.tsx:341
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:544
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:563
 #: src/Components/Modules/UploadFileModule.tsx:115
 msgid "Cancel"
 msgstr "Cancel"
@@ -126,7 +126,7 @@ msgstr "Close"
 msgid "Complete"
 msgstr "Complete"
 
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:544
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:563
 msgid "Confirm"
 msgstr "Confirm"
 
@@ -196,7 +196,7 @@ msgstr "Create"
 msgid "Create Folder"
 msgstr "Create Folder"
 
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:461
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:479
 msgid "Create folder"
 msgstr "Create folder"
 
@@ -209,7 +209,7 @@ msgstr "Dark mode"
 msgid "Date uploaded"
 msgstr "Date uploaded"
 
-#: src/Components/Modules/FilePreviewModal.tsx:182
+#: src/Components/Modules/FilePreviewModal.tsx:188
 msgid "Decryption failed"
 msgstr "Decryption failed"
 
@@ -217,17 +217,17 @@ msgstr "Decryption failed"
 msgid "Delete"
 msgstr "Delete"
 
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:485
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:505
 msgid "Delete selected"
 msgstr "Delete selected"
 
-#: src/Components/Elements/ShareTransferRequestModal.tsx:91
+#: src/Components/Elements/ShareTransferRequestModal.tsx:95
 msgid "Device awaiting confirmation"
 msgstr "Device awaiting confirmation"
 
 #: src/Components/Modules/FileBrowsers/views/FileSystemItemRow.tsx:181
-#: src/Components/Modules/FilePreviewModal.tsx:289
-#: src/Components/Modules/FilePreviewModal.tsx:324
+#: src/Components/Modules/FilePreviewModal.tsx:294
+#: src/Components/Modules/FilePreviewModal.tsx:329
 msgid "Download"
 msgstr "Download"
 
@@ -235,11 +235,11 @@ msgstr "Download"
 msgid "Download complete"
 msgstr "Download complete"
 
-#: src/Components/Modules/Settings/SavedBrowsers/BrowserPanel.tsx:124
+#: src/Components/Modules/Settings/SavedBrowsers/BrowserPanel.tsx:123
 msgid "Download recovery key"
 msgstr "Download recovery key"
 
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:428
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:446
 msgid "Drop to upload files"
 msgstr "Drop to upload files"
 
@@ -292,7 +292,7 @@ msgstr "File"
 msgid "File Info"
 msgstr "File Info"
 
-#: src/Components/Modules/FilePreviewModal.tsx:321
+#: src/Components/Modules/FilePreviewModal.tsx:326
 msgid "File format not supported."
 msgstr "File format not supported."
 
@@ -308,7 +308,6 @@ msgstr "File renamed successfully"
 msgid "File size"
 msgstr "File size"
 
-#: src/Components/Layouts/AppNav.tsx:223
 #: src/Components/Modules/SearchModule.tsx:198
 msgid "Files"
 msgstr "Files"
@@ -332,11 +331,11 @@ msgstr "Folder created successfully"
 msgid "Folders"
 msgstr "Folders"
 
-#: src/Components/Modules/Settings/SavedBrowsers/BrowserPanel.tsx:134
+#: src/Components/Modules/Settings/SavedBrowsers/BrowserPanel.tsx:133
 msgid "Forget this browser"
 msgstr "Forget this browser"
 
-#: src/Components/Modules/Settings/SavedBrowsers/BrowserPanel.tsx:130
+#: src/Components/Modules/Settings/SavedBrowsers/BrowserPanel.tsx:129
 msgid "Forgetting this browser deletes this from your list of sign-in methods. You will not be able to forget a browser if you only have two methods set up."
 msgstr "Forgetting this browser deletes this from your list of sign-in methods. You will not be able to forget a browser if you only have two methods set up."
 
@@ -408,7 +407,7 @@ msgstr "I’m done saving my backup phrase"
 msgid "Learn more"
 msgstr "Learn more"
 
-#: src/Components/Pages/LoginPage.tsx:191
+#: src/Components/Pages/LoginPage.tsx:195
 msgid "Learn more about ChainSafe"
 msgstr "Learn more about ChainSafe"
 
@@ -421,7 +420,7 @@ msgstr "Let's do it"
 msgid "Light mode"
 msgstr "Light mode"
 
-#: src/Components/Modules/FilePreviewModal.tsx:306
+#: src/Components/Modules/FilePreviewModal.tsx:311
 msgid "Loading preview"
 msgstr "Loading preview"
 
@@ -437,12 +436,12 @@ msgstr "Logged in with Web3"
 msgid "Looks like you’re signing in from a new browser. Please choose one of the following to continue:"
 msgstr "Looks like you’re signing in from a new browser. Please choose one of the following to continue:"
 
-#: src/Components/Modules/FileBrowsers/MoveFileModal.tsx:155
+#: src/Components/Modules/FileBrowsers/MoveFileModal.tsx:156
 #: src/Components/Modules/FileBrowsers/views/FileSystemItemRow.tsx:190
 msgid "Move"
 msgstr "Move"
 
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:482
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:500
 msgid "Move selected"
 msgstr "Move selected"
 
@@ -454,11 +453,11 @@ msgstr "Move to..."
 msgid "My Files"
 msgstr "My Files"
 
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:510
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:530
 msgid "Name"
 msgstr "Name"
 
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:443
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:461
 msgid "New folder"
 msgstr "New folder"
 
@@ -471,9 +470,13 @@ msgstr "Next"
 msgid "Nice to see you again!"
 msgstr "Nice to see you again!"
 
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:498
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:518
 msgid "No files to show"
 msgstr "No files to show"
+
+#: src/Components/Modules/FileBrowsers/MoveFileModal.tsx:147
+msgid "No folders"
+msgstr "No folders"
 
 #: src/Components/Modules/SearchModule.tsx:193
 msgid "No search results for"
@@ -491,11 +494,11 @@ msgstr "Number of copies (Replication Factor)"
 msgid "OK"
 msgstr "OK"
 
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:491
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:511
 msgid "One sec, getting files ready..."
 msgstr "One sec, getting files ready..."
 
-#: src/Components/Modules/Settings/SavedBrowsers/BrowserPanel.tsx:108
+#: src/Components/Modules/Settings/SavedBrowsers/BrowserPanel.tsx:107
 msgid "Operating system:"
 msgstr "Operating system:"
 
@@ -578,9 +581,13 @@ msgstr "Recover"
 msgid "Recover with passphrase"
 msgstr "Recover with passphrase"
 
-#: src/Components/Elements/ShareTransferRequestModal.tsx:104
+#: src/Components/Elements/ShareTransferRequestModal.tsx:108
 msgid "Reject"
 msgstr "Reject"
+
+#: src/Components/Elements/ShareTransferRequestModal.tsx:117
+msgid "Reject all"
+msgstr "Reject all"
 
 #: src/Components/Modules/LoginModule/SignInMethods.tsx:251
 msgid "Remind me later"
@@ -594,7 +601,7 @@ msgstr "Rename"
 msgid "Rename File/Folder"
 msgstr "Rename File/Folder"
 
-#: src/Components/Elements/ShareTransferRequestModal.tsx:95
+#: src/Components/Elements/ShareTransferRequestModal.tsx:99
 msgid "Requested from"
 msgstr "Requested from"
 
@@ -636,11 +643,11 @@ msgstr "Saved Browsers"
 msgid "Saved browser"
 msgstr "Saved browser"
 
-#: src/Components/Modules/Settings/SavedBrowsers/BrowserPanel.tsx:117
+#: src/Components/Modules/Settings/SavedBrowsers/BrowserPanel.tsx:116
 msgid "Saved on:"
 msgstr "Saved on:"
 
-#: src/Components/Modules/FileBrowsers/SearchFileBrowser.tsx:61
+#: src/Components/Modules/FileBrowsers/SearchFileBrowser.tsx:67
 msgid "Search results"
 msgstr "Search results"
 
@@ -725,7 +732,7 @@ msgstr "Sign in with a different account"
 msgid "Sign-in methods"
 msgstr "Sign-in methods"
 
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:514
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:534
 msgid "Size"
 msgstr "Size"
 
@@ -796,11 +803,11 @@ msgstr "There was an error getting file info"
 msgid "There was an error getting folder info"
 msgstr "There was an error getting folder info"
 
-#: src/Contexts/DriveContext.tsx:554
+#: src/Contexts/DriveContext.tsx:563
 msgid "There was an error getting search results"
 msgstr "There was an error getting search results"
 
-#: src/Components/Modules/FilePreviewModal.tsx:189
+#: src/Components/Modules/FilePreviewModal.tsx:195
 msgid "There was an error getting the preview."
 msgstr "There was an error getting the preview."
 
@@ -828,8 +835,8 @@ msgstr "Try another method"
 msgid "Update"
 msgstr "Update"
 
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:449
-#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:469
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:467
+#: src/Components/Modules/FileBrowsers/views/FilesTable.view.tsx:487
 msgid "Upload"
 msgstr "Upload"
 
@@ -881,13 +888,13 @@ msgstr "You can change this later."
 msgid "You will need to sign a message in your wallet to complete sign in."
 msgstr "You will need to sign a message in your wallet to complete sign in."
 
-#: src/Components/Modules/Settings/SavedBrowsers/BrowserPanel.tsx:121
+#: src/Components/Modules/Settings/SavedBrowsers/BrowserPanel.tsx:120
 msgid "Your recovery key can be used to restore your account in place of your backup phrase."
 msgstr "Your recovery key can be used to restore your account in place of your backup phrase."
 
 #: src/Components/Layouts/AppNav.tsx:227
-msgid "beta"
-msgstr "beta"
+#~ msgid "beta"
+#~ msgstr "beta"
 
 #: src/Components/Modules/FileBrowsers/FileInfoModal.tsx:200
 msgid "copied !"
@@ -910,7 +917,7 @@ msgstr "file"
 msgid "folder"
 msgstr "folder"
 
-#: src/Components/Elements/ShareTransferRequestModal.tsx:97
+#: src/Components/Elements/ShareTransferRequestModal.tsx:101
 msgid "on"
 msgstr "on"
 


### PR DESCRIPTION
Followup of https://github.com/ChainSafe/files-ui/pull/931#discussion_r614777786
- remove any function in `useState`, this is bad practice and easy to avoid in our case
- use a single `moveToTrash` that accepts an array and uses a promise.all to have things deleted in parallel -> noticeably quicker
- remove a lot of props that ended up being passed from components to components although they originate from a context and can be accessed directly
- have the confirmation modal be in the middle of the screen, like all other modals, instead of the top (closes #https://github.com/ChainSafe/files-ui/issues/937)