### PR TITLE
Log out if ID token is invalid

### DIFF
--- a/packages/files-ui/src/Contexts/ThresholdKeyContext.tsx
+++ b/packages/files-ui/src/Contexts/ThresholdKeyContext.tsx
@@ -290,7 +290,6 @@ const ThresholdKeyProvider = ({ children, network = "mainnet", enableLogging = f
     const loginWithThresholdKey = async () => {
       if (!userInfo) return
       const decodedIdToken = jwtDecode<{exp: number}>(userInfo.userInfo.idToken || "")
-      console.log(dayjs.unix(decodedIdToken.exp).toISOString())
       if (privateKey && dayjs.unix(decodedIdToken.exp).isAfter(dayjs())) {
         const pubKey = EthCrypto.publicKeyByPrivateKey(privateKey)
         setPublicKey(pubKey)


### PR DESCRIPTION
Resolves problems with expired Service Identity Token being used to authenticate against the API.

The Service Identity Token expiration is also being increased to 1 day to align with the refresh token validity.