### PR TITLE
Wait 2min for the initial load

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Cypress Tests with Dependency and Artifact Caching
+name: Cypress Tests
 on: pull_request
 jobs:
   cypress-run:

--- a/packages/files-ui/cypress.json
+++ b/packages/files-ui/cypress.json
@@ -1,1 +1,3 @@
-{}
+{
+    "pageLoadTimeout":  120000
+}


### PR DESCRIPTION
Let's see if this fixes the random Setting test failing. I'm very dubious about it because I don't see why this one specifically fails and not the others
```
 1) Settings
 |        can navigate to the settings security page on a phone:
 |      CypressError: Timed out after waiting `60000ms` for your remote page to load.
 | 
 | Your page did not fire its `load` event within `60000ms`.
```