### PR TITLE
Handle walletconnect signature request

### DIFF
--- a/packages/files-ui/src/Contexts/FilesContext.tsx
+++ b/packages/files-ui/src/Contexts/FilesContext.tsx
@@ -320,9 +320,7 @@ const FilesProvider = ({ children }: FilesContextProps) => {
         dispatchUploadsInProgress({ type: "remove", payload: { id } })
       }, REMOVE_UPLOAD_PROGRESS_DELAY)
     }
-  }, [addToastMessage, filesApiClient, buckets])
-
-
+  }, [addToastMessage, filesApiClient, buckets, refreshBuckets])
 
   const getFileContent = useCallback(async (
     bucketId: string,

--- a/packages/files-ui/src/Contexts/ThresholdKeyContext.tsx
+++ b/packages/files-ui/src/Contexts/ThresholdKeyContext.tsx
@@ -525,9 +525,9 @@ const ThresholdKeyProvider = ({ children, network = "mainnet", enableLogging = f
 
       setStatus("awaiting confirmation")
       const signature = (wallet?.name === "WalletConnect")
-      ? await signer.provider.send("personal_sign", [token, addressToUse])
-      : await signer.signMessage(token)
-      
+        ? await signer.provider.send("personal_sign", [token, addressToUse])
+        : await signer.signMessage(token)
+
       setStatus("logging in")
       const web3IdentityToken = await filesApiClient.postIdentityWeb3Token({
         signature: signature,


### PR DESCRIPTION
Replace the built in `eth_sign` method used by `ethers` with a custom RPC call using `personal_sign`

Closes #1123 