### PR TITLE
Make cypress tests use chrome version 90 in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on: pull_request
 jobs:
   cypress-run:
     runs-on: ubuntu-latest
-    container: cypress/browsers:node12.18.3-chrome87-ff82
+    container: cypress/browsers:node14.16.0-chrome90-ff88
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/packages/files-ui/package.json
+++ b/packages/files-ui/package.json
@@ -77,7 +77,7 @@
     "sentry": "(export REACT_APP_SENTRY_RELEASE=$(sentry-cli releases propose-version); node scripts/sentry.js)",
     "release": "(export REACT_APP_SENTRY_RELEASE=$(sentry-cli releases propose-version); yarn compile && yarn build && node scripts/sentry.js)",
     "test": "cypress open",
-    "test:ci": "cypress run",
+    "test:ci": "cypress run --browser chrome",
     "analyze": "source-map-explorer 'build/static/js/*.js'",
     "extract": "lingui extract",
     "compile": "lingui compile",

--- a/packages/storage-ui/package.json
+++ b/packages/storage-ui/package.json
@@ -76,7 +76,7 @@
     "sentry": "(export REACT_APP_SENTRY_RELEASE=$(sentry-cli releases propose-version); node scripts/sentry.js)",
     "release": "(export REACT_APP_SENTRY_RELEASE=$(sentry-cli releases propose-version); yarn compile && yarn build && node scripts/sentry.js)",
     "test": "cypress open",
-    "test:ci": "cypress run",
+    "test:ci": "cypress run --browser chrome",
     "analyze": "source-map-explorer 'build/static/js/*.js'",
     "extract": "lingui extract",
     "compile": "lingui compile",


### PR DESCRIPTION
Related to "Improvement B" mentioned in #1131

*What I changed* 

- Updated the docker container being used in ci
- Specified cypress to run tests in the chrome browser instead of the default (electron) 
