### PR TITLE
Fix lint action for forked repos

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,8 +6,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.pull_request.head.ref }}
 
     - name: set user
       run: |


### PR DESCRIPTION
Lint is failing for https://github.com/ChainSafe/files-ui/pull/1196 because of this "with" apparently. Also I don't know why this line was useful in the first place, I copy pasted it from an example :man_shrugging: What it does is get the branch from the current repo, but this doesn't work for forked repos.