### PR TITLE
Use BucketKeyPermission instead of missleading Bucket

### DIFF
--- a/packages/files-ui/src/Components/Modules/FileBrowsers/BinFileBrowser.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/BinFileBrowser.tsx
@@ -154,7 +154,7 @@ const BinFileBrowser: React.FC<IFileBrowserModuleProps> = ({ controls = false }:
 
   return (
     <FileBrowserContext.Provider value={{
-      bucket: bucket,
+      bucket,
       crumbs: undefined,
       deleteItems,
       recoverItems,

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/SharedFolderRowWrapper.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/SharedFolderRowWrapper.tsx
@@ -8,6 +8,7 @@ import { makeStyles, createStyles, useDoubleClick, useThemeSwitcher } from "@cha
 import { Trans } from "@lingui/macro"
 import { CSFTheme } from "../../../Themes/types"
 import SharedFolderRow from "./views/FileSystemItem/SharedFolderRow"
+import { BucketKeyPermission } from "../../../Contexts/FilesContext"
 
 const useStyles = makeStyles(({ breakpoints, constants }: CSFTheme) => {
   return createStyles({
@@ -76,7 +77,12 @@ const useStyles = makeStyles(({ breakpoints, constants }: CSFTheme) => {
   })
 })
 
-const SharedFolderRowWrapper = () => {
+interface Props {
+  bucket: BucketKeyPermission
+  handleRename: (bucket: BucketKeyPermission, newName: string) => void
+}
+
+const SharedFolderRowWrapper = ({ bucket, handleRename }: Props) => {
   const { desktop } = useThemeSwitcher()
   const classes = useStyles()
   const [isEditing, setIsEditing] = useState(false)
@@ -140,8 +146,10 @@ const SharedFolderRowWrapper = () => {
     <SharedFolderRow
       menuItems={menuItems}
       onFolderClick={onFolderClick}
+      bucket={bucket}
       isEditing={isEditing}
       setIsEditing={setIsEditing}
+      handleRename={handleRename}
     />
   )
 }

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/SharedFolderRowWrapper.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/SharedFolderRowWrapper.tsx
@@ -8,7 +8,6 @@ import { makeStyles, createStyles, useDoubleClick, useThemeSwitcher } from "@cha
 import { Trans } from "@lingui/macro"
 import { CSFTheme } from "../../../Themes/types"
 import SharedFolderRow from "./views/FileSystemItem/SharedFolderRow"
-import { BucketKeyPermission } from "../../../Contexts/FilesContext"
 
 const useStyles = makeStyles(({ breakpoints, constants }: CSFTheme) => {
   return createStyles({
@@ -77,12 +76,7 @@ const useStyles = makeStyles(({ breakpoints, constants }: CSFTheme) => {
   })
 })
 
-interface Props {
-  bucket: BucketKeyPermission
-  handleRename: (bucket: BucketKeyPermission, newName: string) => void
-}
-
-const SharedFolderRowWrapper = ({ bucket, handleRename }: Props) => {
+const SharedFolderRowWrapper = () => {
   const { desktop } = useThemeSwitcher()
   const classes = useStyles()
   const [isEditing, setIsEditing] = useState(false)
@@ -146,10 +140,8 @@ const SharedFolderRowWrapper = ({ bucket, handleRename }: Props) => {
     <SharedFolderRow
       menuItems={menuItems}
       onFolderClick={onFolderClick}
-      bucket={bucket}
       isEditing={isEditing}
       setIsEditing={setIsEditing}
-      handleRename={handleRename}
     />
   )
 }

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/SharedFolderRowWrapper.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/SharedFolderRowWrapper.tsx
@@ -7,8 +7,8 @@ import {
 import { makeStyles, createStyles, useDoubleClick, useThemeSwitcher } from "@chainsafe/common-theme"
 import { Trans } from "@lingui/macro"
 import { CSFTheme } from "../../../Themes/types"
-import { Bucket } from "@chainsafe/files-api-client"
 import SharedFolderRow from "./views/FileSystemItem/SharedFolderRow"
+import { BucketKeyPermission } from "../../../Contexts/FilesContext"
 
 const useStyles = makeStyles(({ breakpoints, constants }: CSFTheme) => {
   return createStyles({
@@ -78,8 +78,8 @@ const useStyles = makeStyles(({ breakpoints, constants }: CSFTheme) => {
 })
 
 interface Props {
-  bucket: Bucket
-  handleRename: (bucket: Bucket, newName: string) => void
+  bucket: BucketKeyPermission
+  handleRename: (bucket: BucketKeyPermission, newName: string) => void
 }
 
 const SharedFolderRowWrapper = ({ bucket, handleRename }: Props) => {

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/SharedFoldersOverview.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/SharedFoldersOverview.tsx
@@ -11,7 +11,7 @@ import {
   Button,
   PlusIcon
 } from "@chainsafe/common-components"
-import { useFiles } from "../../../Contexts/FilesContext"
+import { BucketKeyPermission, useFiles } from "../../../Contexts/FilesContext"
 import { Trans } from "@lingui/macro"
 import { createStyles, makeStyles, useThemeSwitcher } from "@chainsafe/common-theme"
 import { CSFTheme } from "../../../Themes/types"
@@ -19,7 +19,6 @@ import SharedFolderRowWrapper from "./SharedFolderRowWrapper"
 import clsx from "clsx"
 import CreateSharedFolderModal from "./CreateSharedFolderModal"
 import { useFilesApi } from "../../../Contexts/FilesApiContext"
-import { Bucket } from "@chainsafe/files-api-client"
 
 export const desktopSharedGridSettings = "69px 3fr 190px 150px 45px !important"
 export const mobileSharedGridSettings = "3fr 50px 45px !important"
@@ -121,7 +120,7 @@ const SharedFolderOverview = () => {
     }
   }
 
-  const handleRename = useCallback((bucket: Bucket, newName: string) => {
+  const handleRename = useCallback((bucket: BucketKeyPermission, newName: string) => {
     filesApiClient.updateBucket(bucket.id, {
       ...bucket,
       name: newName

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/SharedFoldersOverview.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/SharedFoldersOverview.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from "react"
+import React, { useMemo, useState } from "react"
 import {
   Typography,
   Table,
@@ -11,14 +11,13 @@ import {
   Button,
   PlusIcon
 } from "@chainsafe/common-components"
-import { BucketKeyPermission, useFiles } from "../../../Contexts/FilesContext"
+import { useFiles } from "../../../Contexts/FilesContext"
 import { Trans } from "@lingui/macro"
 import { createStyles, makeStyles, useThemeSwitcher } from "@chainsafe/common-theme"
 import { CSFTheme } from "../../../Themes/types"
 import SharedFolderRowWrapper from "./SharedFolderRowWrapper"
 import clsx from "clsx"
 import CreateSharedFolderModal from "./CreateSharedFolderModal"
-import { useFilesApi } from "../../../Contexts/FilesApiContext"
 
 export const desktopSharedGridSettings = "69px 3fr 190px 150px 45px !important"
 export const mobileSharedGridSettings = "3fr 50px 45px !important"
@@ -96,8 +95,7 @@ const useStyles = makeStyles(
 
 const SharedFolderOverview = () => {
   const classes = useStyles()
-  const { filesApiClient } = useFilesApi()
-  const { buckets, isLoadingBuckets, refreshBuckets } = useFiles()
+  const { buckets, isLoadingBuckets } = useFiles()
   const [createSharedFolderModalOpen, setCreateSharedFolderModalOpen] = useState(false)
   const [direction, setDirection] = useState<SortDirection>("ascend")
   const [column, setColumn] = useState<"name" | "size" | "date_uploaded">("name")
@@ -119,14 +117,6 @@ const SharedFolderOverview = () => {
       }
     }
   }
-
-  const handleRename = useCallback((bucket: BucketKeyPermission, newName: string) => {
-    filesApiClient.updateBucket(bucket.id, {
-      ...bucket,
-      name: newName
-    }).then(() => refreshBuckets(false))
-      .catch(console.error)
-  }, [filesApiClient, refreshBuckets])
 
   return (
     <>
@@ -205,8 +195,6 @@ const SharedFolderOverview = () => {
               {bucketsToShow.map((bucket) =>
                 <SharedFolderRowWrapper
                   key={bucket.id}
-                  bucket={bucket}
-                  handleRename={handleRename}
                 />
               )}
             </TableBody>

--- a/packages/files-ui/src/Contexts/FileBrowserContext.tsx
+++ b/packages/files-ui/src/Contexts/FileBrowserContext.tsx
@@ -1,10 +1,10 @@
 import { Crumb } from "@chainsafe/common-components"
 import React, { useContext } from "react"
 import { FileOperation, IBulkOperations, IFileBrowserModuleProps } from "../Components/Modules/FileBrowsers/types"
-import { FileSystemItem, UploadProgress } from "./FilesContext"
-import { Bucket } from "@chainsafe/files-api-client"
+import { BucketKeyPermission, FileSystemItem, UploadProgress } from "./FilesContext"
+
 interface FileBrowserContext extends IFileBrowserModuleProps {
-  bucket?: Bucket
+  bucket?: BucketKeyPermission
   itemOperations: {[contentType: string]: FileOperation[]}
   bulkOperations?: IBulkOperations
   renameItem?: (cid: string, newName: string) => Promise<void>

--- a/packages/files-ui/src/Contexts/FilesContext.tsx
+++ b/packages/files-ui/src/Contexts/FilesContext.tsx
@@ -59,13 +59,13 @@ interface GetFileContentParams {
 
 type BucketPermission = "writer" | "owner" | "reader"
 
-type Bucket = FilesBucket & {
+export type BucketKeyPermission = FilesBucket & {
   encryptionKey: string
   permission?: BucketPermission
 }
 
 type FilesContext = {
-  buckets: Bucket[]
+  buckets: BucketKeyPermission[]
   uploadsInProgress: UploadProgress[]
   downloadsInProgress: DownloadProgress[]
   spaceUsed: number
@@ -104,7 +104,7 @@ const FilesProvider = ({ children }: FilesContextProps) => {
   const { addToastMessage } = useToaster()
   const [spaceUsed, setSpaceUsed] = useState(0)
   const [personalEncryptionKey, setPersonalEncryptionKey] = useState<string | undefined>()
-  const [buckets, setBuckets] = useState<Bucket[]>([])
+  const [buckets, setBuckets] = useState<BucketKeyPermission[]>([])
   const { profile } = useUser()
   const { userId } = profile || {}
   const [isLoadingBuckets, setIsLoadingBuckets] = useState(false)
@@ -129,7 +129,7 @@ const FilesProvider = ({ children }: FilesContextProps) => {
     showLoading && setIsLoadingBuckets(true)
     const result = await filesApiClient.listBuckets()
 
-    const bucketsWithKeys: Bucket[] = await Promise.all(
+    const bucketsWithKeys: BucketKeyPermission[] = await Promise.all(
       result.map(async (b) => {
 
         const permission = b.owners.find(owner => owner === profile?.userId)

--- a/packages/files-ui/src/Contexts/FilesContext.tsx
+++ b/packages/files-ui/src/Contexts/FilesContext.tsx
@@ -132,11 +132,11 @@ const FilesProvider = ({ children }: FilesContextProps) => {
     const bucketsWithKeys: BucketKeyPermission[] = await Promise.all(
       result.map(async (b) => {
 
-        const permission = b.owners.find(owner => owner === profile?.userId)
+        const permission = b.owners.find(owner => owner.uuid === profile?.userId)
           ? "owner" as BucketPermission
-          : b.writers.find(writer => writer === profile?.userId)
+          : b.writers.find(writer => writer.uuid === profile?.userId)
             ? "writer" as BucketPermission
-            : b.readers.find(reader => reader === profile?.userId)
+            : b.readers.find(reader => reader.uuid === profile?.userId)
               ? "reader" as BucketPermission
               : undefined
 
@@ -160,6 +160,7 @@ const FilesProvider = ({ children }: FilesContextProps) => {
         }
       })
     )
+    console.log(bucketsWithKeys)
     setBuckets(bucketsWithKeys)
     setIsLoadingBuckets(false)
     return Promise.resolve()


### PR DESCRIPTION
Renaming the `Bucket` type (that extends `Bucket` from the api-spec) so that our VSC aren't mislead, and so that we can use the `permission` that `BucketKeyPermission` actually has.

Our FilesContext is actually enhancing the `Bucket` type from the api-spec, and adds some more fields such as the encryption key, and the permission for the current user. I've replaced it here with a clearer type `BucketKeyPermission`


small fix along the way, prevent the overkill use of regex.