### PR TITLE
Fix bulk operations for csf buckets

### DIFF
--- a/packages/files-ui/src/Components/Modules/FileBrowsers/views/FilesList.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/views/FilesList.tsx
@@ -487,34 +487,23 @@ const FilesList = ({ isShared = false }: Props) => {
         fileOperations = baseOperations
         break
       }
+    }
 
-      for (let i = 0; i < selectedCids.length; i++) {
-        const contentType = items.find((item) => item.cid === selectedCids[i])
-          ?.content_type
+    for (let i = 0; i < selectedCids.length; i++) {
+      const contentType = items.find((item) => item.cid === selectedCids[i])
+        ?.content_type
 
-        if (contentType) {
-          if (contentType === CONTENT_TYPES.Directory) {
-            const validList = fileOperations.filter(
-              (op: FileOperation) =>
-                bulkOperations[contentType].indexOf(op) >= 0
+      if (contentType) {
+        if (contentType === CONTENT_TYPES.Directory) {
+          const validList = fileOperations.filter(
+            (op: FileOperation) =>
+              bulkOperations[contentType].indexOf(op) >= 0
+          )
+          if (validList.length > 0) {
+            fileOperations = fileOperations.filter(
+              (existingOp: FileOperation) =>
+                validList.indexOf(existingOp) >= 0
             )
-            if (validList.length > 0) {
-              fileOperations = fileOperations.filter(
-                (existingOp: FileOperation) =>
-                  validList.indexOf(existingOp) >= 0
-              )
-            }
-          } else {
-            const validList = fileOperations.filter(
-              (op: FileOperation) =>
-                bulkOperations[CONTENT_TYPES.File].indexOf(op) >= 0
-            )
-            if (validList.length > 0) {
-              fileOperations = fileOperations.filter(
-                (existingOp: FileOperation) =>
-                  validList.indexOf(existingOp) >= 0
-              )
-            }
           }
         } else {
           const validList = fileOperations.filter(
@@ -523,13 +512,24 @@ const FilesList = ({ isShared = false }: Props) => {
           )
           if (validList.length > 0) {
             fileOperations = fileOperations.filter(
-              (existingOp: FileOperation) => validList.indexOf(existingOp) >= 0
+              (existingOp: FileOperation) =>
+                validList.indexOf(existingOp) >= 0
             )
           }
         }
+      } else {
+        const validList = fileOperations.filter(
+          (op: FileOperation) =>
+            bulkOperations[CONTENT_TYPES.File].indexOf(op) >= 0
+        )
+        if (validList.length > 0) {
+          fileOperations = fileOperations.filter(
+            (existingOp: FileOperation) => validList.indexOf(existingOp) >= 0
+          )
+        }
       }
-      setValidBulkOps(fileOperations)
     }
+    setValidBulkOps(fileOperations)
   }, [selectedCids, items, bulkOperations, isShared, permission])
 
   const handleDeleteFiles = useCallback(() => {
@@ -597,6 +597,7 @@ const FilesList = ({ isShared = false }: Props) => {
     setIsDeleteModalOpen(true)
   }, [])
 
+  console.log("validBulkOps.indexOf(move)", validBulkOps.indexOf("move"))
   return (
     <article
       className={clsx(classes.root, {

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/views/FilesList.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/views/FilesList.tsx
@@ -597,7 +597,6 @@ const FilesList = ({ isShared = false }: Props) => {
     setIsDeleteModalOpen(true)
   }, [])
 
-  console.log("validBulkOps.indexOf(move)", validBulkOps.indexOf("move"))
   return (
     <article
       className={clsx(classes.root, {


### PR DESCRIPTION
This is fix for a bug I introduced in https://github.com/ChainSafe/files-ui/pull/1219/ 
How to reproduce, select at least 1 File in a csf bucket (normal, non shared bucket) and see that the bulk operation buttons don't show up.

edit: Github shows a complex diff but the reality is just a `if (!!permission && isShared) {` that was closed too late, it should be closed right after the `switch`.