### PR TITLE
Fix shared folder creation path

### DIFF
--- a/packages/files-ui/src/Components/FilesRoutes.tsx
+++ b/packages/files-ui/src/Components/FilesRoutes.tsx
@@ -27,8 +27,13 @@ export const ROUTE_LINKS = {
   UserSurvey: "https://shrl.ink/kmAL",
   GeneralFeedbackForm: "https://shrl.ink/gvVJ",
   SharedFolders: "/shared-overview",
-  ShareBrowserRoot: "/shared",
-  ShareExplorer: (bucketId: string, rawCurrentPath: string) => `/shared/${bucketId}${rawCurrentPath}`
+  SharedFolderBrowserRoot: "/shared",
+  SharedFolderExplorer: (bucketId: string, rawCurrentPath: string) => {
+    // bucketId should not have a / at the end
+    // rawCurrentPath can be empty, or /
+    const adjustedRawCurrentPath = !rawCurrentPath ? "/" : rawCurrentPath
+    return `/shared/${bucketId}${adjustedRawCurrentPath}`
+  }
 }
 
 export const SETTINGS_PATHS = ["profile", "plan", "security"] as const
@@ -50,7 +55,7 @@ const FilesRoutes = () => {
         redirectPath={ROUTE_LINKS.Landing}
       />
       <ConditionalRoute
-        path={ROUTE_LINKS.ShareBrowserRoot}
+        path={ROUTE_LINKS.SharedFolderBrowserRoot}
         isAuthorized={isAuthorized}
         component={ShareFilesPage}
         redirectPath={ROUTE_LINKS.Landing}

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/MoveFileModal.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/MoveFileModal.tsx
@@ -100,7 +100,7 @@ const MoveFileModule = ({ filesToMove, modalOpen, onClose, onCancel, mode }: IMo
         const folderTreeNodes = [
           {
             id: "/",
-            title: "Home",
+            title: bucket.name || "Home",
             isExpanded: true,
             expandable: true,
             tree: mapFolderTree(newFolderTree.entries)

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/MoveFileModal.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/MoveFileModal.tsx
@@ -97,32 +97,16 @@ const MoveFileModule = ({ filesToMove, modalOpen, onClose, onCancel, mode }: IMo
     if (!bucket) return
     filesApiClient.getBucketDirectoriesTree(bucket.id).then((newFolderTree) => {
       if (newFolderTree.entries) {
-        if (bucket.type === "share") {
-          // shared folder tree
-          const shareFolderTreeRoot = newFolderTree.entries[0].entries[0]
-          const folderTreeNodes = [
-            {
-              id: "/",
-              title: bucket.name || "Root",
-              isExpanded: true,
-              expandable: true,
-              tree: mapFolderTree(shareFolderTreeRoot.entries)
-            }
-          ]
-          setFolderTree(folderTreeNodes)
-        } else {
-          // others folder tree
-          const folderTreeNodes = [
-            {
-              id: "/",
-              title: "Home",
-              isExpanded: true,
-              expandable: true,
-              tree: mapFolderTree(newFolderTree.entries)
-            }
-          ]
-          setFolderTree(folderTreeNodes)
-        }
+        const folderTreeNodes = [
+          {
+            id: "/",
+            title: "Home",
+            isExpanded: true,
+            expandable: true,
+            tree: mapFolderTree(newFolderTree.entries)
+          }
+        ]
+        setFolderTree(folderTreeNodes)
       } else {
         setFolderTree([])
       }

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/SharedFoldersOverview.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/SharedFoldersOverview.tsx
@@ -132,7 +132,7 @@ const SharedFolderOverview = () => {
   }, [filesApiClient, refreshBuckets])
 
   const openSharedFolder = useCallback((bucketId: string) => {
-    redirect(ROUTE_LINKS.ShareExplorer(bucketId, "/"))
+    redirect(ROUTE_LINKS.SharedFolderExplorer(bucketId, "/"))
   }, [redirect])
 
   return (

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/Sharing/ShareFileBrowser.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/Sharing/ShareFileBrowser.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react"
 import { useToaster, useHistory, useLocation, Crumb } from "@chainsafe/common-components"
-import { getArrayOfPaths, getURISafePathFromArray, getPathWithFile, extractFileBrowserPathFromURL } from "../../../../Utils/pathUtils"
+import { getArrayOfPaths, getURISafePathFromArray, getPathWithFile, extractSharedFileBrowserPathFromURL } from "../../../../Utils/pathUtils"
 import { IBulkOperations, IFilesTableBrowserProps } from "../types"
 import { CONTENT_TYPES } from "../../../../Utils/Constants"
 import { t } from "@lingui/macro"
@@ -14,11 +14,7 @@ import DragAndDrop from "../../../../Contexts/DnDContext"
 import FilesList from "../views/FilesList"
 
 const ShareFileBrowser = () => {
-  const {
-    downloadFile,
-    uploadFiles,
-    buckets
-  } = useFiles()
+  const { downloadFile, uploadFiles, buckets } = useFiles()
   const { filesApiClient } = useFilesApi()
   const { addToastMessage } = useToaster()
   const [loadingCurrentPath, setLoadingCurrentPath] = useState(false)
@@ -33,7 +29,7 @@ const ShareFileBrowser = () => {
   const bucket = useMemo(() => buckets.find(b => b.id === bucketId), [buckets, bucketId])
 
   const currentPath = useMemo(() => {
-    return extractFileBrowserPathFromURL(pathname, ROUTE_LINKS.ShareExplorer(`${bucketId}/`, "/"))
+    return extractSharedFileBrowserPathFromURL(pathname, ROUTE_LINKS.SharedFolderExplorer(bucketId, ""))
   },
   [bucketId, pathname])
 
@@ -42,13 +38,13 @@ const ShareFileBrowser = () => {
   const [access, setAccess] = useState<BucketPermission>("reader")
 
   // Breadcrumbs/paths
-  const arrayOfPaths = useMemo(() => getArrayOfPaths(currentPath).splice(2), [currentPath])
+  const arrayOfPaths = useMemo(() => getArrayOfPaths(currentPath), [currentPath])
   const crumbs: Crumb[] = useMemo(() => arrayOfPaths.map((path, index) => {
     return ({
       text: decodeURIComponent(path),
       onClick: () => {
         redirect(
-          ROUTE_LINKS.ShareExplorer(`${bucket?.id}`, getURISafePathFromArray(arrayOfPaths.slice(0, index + 1)))
+          ROUTE_LINKS.SharedFolderExplorer(bucket?.id || "", getURISafePathFromArray(arrayOfPaths.slice(0, index + 1)))
         )
       }
     })
@@ -162,11 +158,11 @@ const ShareFileBrowser = () => {
 
     const fileSystemItem = pathContents.find(f => f.cid === cid)
     if (fileSystemItem && fileSystemItem.content_type === CONTENT_TYPES.Directory) {
-      let urlSafePath =  getURISafePathFromArray(getArrayOfPaths(currentPath).splice(2))
+      let urlSafePath =  getURISafePathFromArray(getArrayOfPaths(currentPath))
       if (urlSafePath === "/") {
         urlSafePath = ""
       }
-      redirect(ROUTE_LINKS.ShareExplorer(bucket.id, `${urlSafePath}/${encodeURIComponent(`${fileSystemItem.name}`)}`))
+      redirect(ROUTE_LINKS.SharedFolderExplorer(bucket.id, `${urlSafePath}/${encodeURIComponent(`${fileSystemItem.name}`)}`))
     }
   }, [currentPath, pathContents, redirect, bucket])
 
@@ -238,7 +234,7 @@ const ShareFileBrowser = () => {
       bulkOperations,
       handleUploadOnDrop,
       crumbs,
-      moduleRootPath: ROUTE_LINKS.ShareExplorer(`${bucket?.id}`, "/"),
+      moduleRootPath: ROUTE_LINKS.SharedFolderExplorer(bucket?.id || "", "/"),
       currentPath,
       refreshContents,
       deleteItems: moveItemsToBin,

--- a/packages/files-ui/src/Utils/pathUtils.ts
+++ b/packages/files-ui/src/Utils/pathUtils.ts
@@ -51,3 +51,10 @@ export function getParentPathFromFilePath(filePath: string) {
 export function extractFileBrowserPathFromURL(browserUrl: string, modulePath: string) {
   return browserUrl.replace(modulePath, "").split("/").map(decodeURIComponent).join("/")
 }
+
+// /shared/{bucket-id}/path/to/somewhere -> /path/to/somewhere
+export function extractSharedFileBrowserPathFromURL(browserUrl: string, modulePath: string) {
+  const res = extractFileBrowserPathFromURL(browserUrl, modulePath)
+  // this path must start by a /
+  return res[0] === "/" ? res : `/${res}`
+}


### PR DESCRIPTION
This PR prevents sending the `/shared/{bucket-id}` to the `api` and tries to create paths similarly to what is done for csf bucket.