### PR TITLE
Fix refresh token flow

### DIFF
--- a/packages/files-ui/src/Contexts/FilesApiContext.tsx
+++ b/packages/files-ui/src/Contexts/FilesApiContext.tsx
@@ -43,7 +43,7 @@ const FilesApiProvider = ({ apiUrl, withLocalStorage = true, children }: FilesAp
 
   const { wallet, onboard, checkIsReady, isReady } = useWeb3()
   const { localStorageRemove, localStorageGet, localStorageSet } = useLocalStorage()
-  const { sessionStorageRemove, sessionStorageGet, sessionStorageSet } = useSessionStorage()
+  const { sessionStorageRemove, sessionStorageSet } = useSessionStorage()
 
   // initializing api
   const initialAxiosInstance = useMemo(() => axios.create({
@@ -99,10 +99,7 @@ const FilesApiProvider = ({ apiUrl, withLocalStorage = true, children }: FilesAp
         async (error) => {
           if (!error?.config?._retry && error?.response?.status === 401 && !maintenanceMode) {
             error.config._retry = true
-            const refreshTokenLocal =
-              (withLocalStorage)
-                ? localStorageGet(tokenStorageKey)
-                : sessionStorageGet(tokenStorageKey)
+            const refreshTokenLocal = sessionStorage.getItem(tokenStorageKey)
             if (refreshTokenLocal) {
               const refreshTokenApiClient = new FilesApiClient(
                 {},


### PR DESCRIPTION
Closes #1224 

Replace call to the session storage helper with direct browser Api calls to `sessionStorage.getItem()` inside the refresh token handler. 