### PR TITLE
Update test suite checks to match latest navigation

### DIFF
--- a/packages/storage-ui/cypress/support/commands.ts
+++ b/packages/storage-ui/cypress/support/commands.ts
@@ -31,7 +31,7 @@ import { ethers, Wallet } from "ethers"
 import { testPrivateKey, localHost } from "../fixtures/loginData"
 import { CustomizedBridge } from "./utils/CustomBridge"
 import "cypress-file-upload"
-import { cidsPage } from "./page-objects/cidsPage"
+import { bucketsPage } from "./page-objects/bucketsPage"
 
 export type Storage = Record<string, string>[];
 
@@ -144,7 +144,7 @@ Cypress.Commands.add(
       }
     })
 
-    cidsPage.cidsHeaderLabel().should("be.visible")
+    bucketsPage.bucketsHeaderLabel().should("be.visible")
 
     cy.saveLocalAndSession()
 
@@ -163,7 +163,7 @@ Cypress.Commands.add(
         }
       })
 
-      cidsPage.cidsHeaderLabel().should("be.visible")
+      bucketsPage.bucketsHeaderLabel().should("be.visible")
     }
   }
 )

--- a/packages/storage-ui/cypress/support/page-objects/bucketsPage.ts
+++ b/packages/storage-ui/cypress/support/page-objects/bucketsPage.ts
@@ -6,7 +6,7 @@ export const bucketsPage = {
   ...basePage,
 
   // main bucket browser elements
-  bucketsHeaderLabel: () => cy.get("[data-cy=buckets-header]", { timeout: 20000 }),
+  bucketsHeaderLabel: () => cy.get("[data-cy=header-buckets]", { timeout: 20000 }),
   createBucketButton: () => cy.get("[data-cy=button-create-bucket]"),
 
   // bucket browser row elements

--- a/packages/storage-ui/src/Components/Modules/FilesList/FilesList.tsx
+++ b/packages/storage-ui/src/Components/Modules/FilesList/FilesList.tsx
@@ -568,11 +568,13 @@ const FilesList = () => {
           />
         )}
       </div>
-      <header className={classes.header}>
+      <header
+        className={classes.header}
+        data-cy="header-bucket-item"
+      >
         <Typography
           variant="h1"
           component="h1"
-          data-cy="buckets-header"
         >
           {heading}
         </Typography>

--- a/packages/storage-ui/src/Components/Pages/BucketsPage.tsx
+++ b/packages/storage-ui/src/Components/Pages/BucketsPage.tsx
@@ -146,7 +146,10 @@ const BucketsPage = () => {
 
   return (
     <div className={classes.root}>
-      <header className={classes.header}>
+      <header
+        className={classes.header}
+        data-cy="header-buckets"
+      >
         <Typography variant='h1'>
           <Trans>
             Buckets

--- a/packages/storage-ui/src/Components/Pages/CidsPage.tsx
+++ b/packages/storage-ui/src/Components/Pages/CidsPage.tsx
@@ -94,11 +94,13 @@ const CidsPage = () => {
   return (
     <>
       <div className={classes.root}>
-        <header className={classes.header}>
+        <header
+          className={classes.header}
+          data-cy="header-cids"
+        >
           <Typography
             variant="h1"
             component="h1"
-            data-cy="cids-header"
           >
             <Trans>
               Cids


### PR DESCRIPTION
closes #1312 

Just a small update to the preliminary checks that we do in automated tests after logging in. Now it expects the buckets page as the default page.

I also updated some identifiers (to be consistent with the style we are using elsewhere). 