### PR TITLE
Escape backslash in "white space error message" regex

### DIFF
--- a/packages/files-ui/src/Utils/validationSchema.ts
+++ b/packages/files-ui/src/Utils/validationSchema.ts
@@ -1,8 +1,7 @@
 import { t } from "@lingui/macro"
 import { object, string } from "yup"
 
-// eslint-disable-next-line 
-const spacesOnlyRegex = new RegExp(`^\s+$`)
+const whitespaceOnlyRegex = new RegExp("^\\s+$")
 
 export const renameSchema = object().shape({
   fileName: string()
@@ -16,8 +15,8 @@ export const renameSchema = object().shape({
     )
     .test(
       "Only whitespace",
-      t`Name cannot only contain whitepsace characters`,
-      (val) => !!val && !spacesOnlyRegex.test(val)
+      t`Name cannot only contain whitespace characters`,
+      (val) => !!val && !whitespaceOnlyRegex.test(val)
     )
 })
 
@@ -34,6 +33,6 @@ export const folderNameValidator = object().shape({
     .test(
       "Only whitespace",
       t`Folder name cannot only contain whitepsace characters`,
-      (val) => !!val && !spacesOnlyRegex.test(val)
+      (val) => !!val && !whitespaceOnlyRegex.test(val)
     )
 })

--- a/packages/files-ui/src/locales/de/messages.po
+++ b/packages/files-ui/src/locales/de/messages.po
@@ -397,7 +397,7 @@ msgstr "Name"
 msgid "Name cannot contain '/' character"
 msgstr "Name darf kein /-Zeichen enthalten"
 
-msgid "Name cannot only contain whitepsace characters"
+msgid "Name cannot only contain whitespace characters"
 msgstr ""
 
 msgid "Name too long"

--- a/packages/files-ui/src/locales/en/messages.po
+++ b/packages/files-ui/src/locales/en/messages.po
@@ -400,8 +400,8 @@ msgstr "Name"
 msgid "Name cannot contain '/' character"
 msgstr "Name cannot contain '/' character"
 
-msgid "Name cannot only contain whitepsace characters"
-msgstr "Name cannot only contain whitepsace characters"
+msgid "Name cannot only contain whitespace characters"
+msgstr "Name cannot only contain whitespace characters"
 
 msgid "Name too long"
 msgstr "Name too long"

--- a/packages/files-ui/src/locales/es/messages.po
+++ b/packages/files-ui/src/locales/es/messages.po
@@ -401,7 +401,7 @@ msgstr "Nombre"
 msgid "Name cannot contain '/' character"
 msgstr ""
 
-msgid "Name cannot only contain whitepsace characters"
+msgid "Name cannot only contain whitespace characters"
 msgstr ""
 
 msgid "Name too long"

--- a/packages/files-ui/src/locales/fr/messages.po
+++ b/packages/files-ui/src/locales/fr/messages.po
@@ -401,7 +401,7 @@ msgstr "Nom"
 msgid "Name cannot contain '/' character"
 msgstr "Le nom ne peut pas contenir le caractère /"
 
-msgid "Name cannot only contain whitepsace characters"
+msgid "Name cannot only contain whitespace characters"
 msgstr ""
 
 msgid "Name too long"

--- a/packages/files-ui/src/locales/no/messages.po
+++ b/packages/files-ui/src/locales/no/messages.po
@@ -397,7 +397,7 @@ msgstr "Navn"
 msgid "Name cannot contain '/' character"
 msgstr ""
 
-msgid "Name cannot only contain whitepsace characters"
+msgid "Name cannot only contain whitespace characters"
 msgstr ""
 
 msgid "Name too long"

--- a/packages/storage-ui/src/Components/Modules/MoveFileModal/MoveFileModal.tsx
+++ b/packages/storage-ui/src/Components/Modules/MoveFileModal/MoveFileModal.tsx
@@ -126,7 +126,7 @@ const MoveFileModal = ({ filesToMove, modalOpen, onClose, onCancel, mode }: IMov
     const moveFn = mode === "move" ? moveItems : recoverItems
     if (!movePath || !moveFn) return
 
-    setMovingFile(true)
+    setIsMovingFile(true)
     moveFn(filesToMove.map(f => ({
       cid: f.cid,
       name: f.name

--- a/packages/storage-ui/src/Utils/validationSchema.ts
+++ b/packages/storage-ui/src/Utils/validationSchema.ts
@@ -15,7 +15,7 @@ export const renameSchema = object().shape({
     )
     .test(
       "Only whitespace",
-      t`Name cannot only contain whitepsace characters`,
+      t`Name cannot only contain whitespace characters`,
       (val) => !!val && !whitespaceOnlyRegex.test(val)
     )
     .required(t`A name is required`)

--- a/packages/storage-ui/src/Utils/validationSchema.ts
+++ b/packages/storage-ui/src/Utils/validationSchema.ts
@@ -2,8 +2,7 @@ import { t } from "@lingui/macro"
 import { object, string } from "yup"
 import { cid as isCid } from "is-ipfs"
 
-// eslint-disable-next-line 
-const spacesOnlyRegex = new RegExp(`^\\s+$`)
+const whitespaceOnlyRegex = new RegExp("^\\s+$")
 
 export const renameSchema = object().shape({
   fileName: string()
@@ -17,7 +16,7 @@ export const renameSchema = object().shape({
     .test(
       "Only whitespace",
       t`Name cannot only contain whitepsace characters`,
-      (val) => !!val && !spacesOnlyRegex.test(val)
+      (val) => !!val && !whitespaceOnlyRegex.test(val)
     )
     .required(t`A name is required`)
 })
@@ -35,7 +34,7 @@ export const folderNameValidator = object().shape({
     .test(
       "Only whitespace",
       t`Folder name cannot only contain whitepsace characters`,
-      (val) => !!val && !spacesOnlyRegex.test(val)
+      (val) => !!val && !whitespaceOnlyRegex.test(val)
     )
 })
 
@@ -52,7 +51,7 @@ export const bucketNameValidator = (bucketNames: Array<string | undefined>) => o
     .test(
       "Only whitespace",
       t`Bucket name cannot only contain whitepsace characters`,
-      (val) => !!val && !spacesOnlyRegex.test(val)
+      (val) => !!val && !whitespaceOnlyRegex.test(val)
     )
     .test(
       "Unique name",

--- a/packages/storage-ui/src/Utils/validationSchema.ts
+++ b/packages/storage-ui/src/Utils/validationSchema.ts
@@ -3,7 +3,7 @@ import { object, string } from "yup"
 import { cid as isCid } from "is-ipfs"
 
 // eslint-disable-next-line 
-const spacesOnlyRegex = new RegExp(`^\s+$`)
+const spacesOnlyRegex = new RegExp(`^\\s+$`)
 
 export const renameSchema = object().shape({
   fileName: string()

--- a/packages/storage-ui/src/locales/en/messages.po
+++ b/packages/storage-ui/src/locales/en/messages.po
@@ -235,8 +235,8 @@ msgstr "Name"
 msgid "Name cannot contain '/' character"
 msgstr "Name cannot contain '/' character"
 
-msgid "Name cannot only contain whitepsace characters"
-msgstr "Name cannot only contain whitepsace characters"
+msgid "Name cannot only contain whitespace characters"
+msgstr "Name cannot only contain whitespace characters"
 
 msgid "Name too long"
 msgstr "Name too long"


### PR DESCRIPTION
closes #1314

**Before** 
<img width="710" alt="Screen Shot 2021-07-22 at 9 01 59 AM" src="https://user-images.githubusercontent.com/3982665/126722747-1f36dd2d-197b-4ec4-bb07-9c0c06eced9d.png">
(and no error was being shown when entering just whitespace)

**After**

<img width="613" alt="Screen Shot 2021-07-22 at 4 31 58 PM" src="https://user-images.githubusercontent.com/3982665/126722803-d1874d50-952b-4f5c-86bc-c45c58f3fb76.png">

<img width="609" alt="Screen Shot 2021-07-22 at 4 32 24 PM" src="https://user-images.githubusercontent.com/3982665/126722799-aa9cdf5e-81f0-4e28-a871-d76a75abac29.png">
(showing as intended now)
