### PR TITLE
Make sure to always use helpers with paths

### DIFF
--- a/packages/files-ui/src/Components/Modules/FileBrowsers/BinFileBrowser.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/BinFileBrowser.tsx
@@ -7,7 +7,7 @@ import { t } from "@lingui/macro"
 import { CONTENT_TYPES } from "../../../Utils/Constants"
 import { IFilesTableBrowserProps } from "../../Modules/FileBrowsers/types"
 import { useHistory, useLocation, useToaster } from "@chainsafe/common-components"
-import { extractFileBrowserPathFromURL, getArrayOfPaths, getPathWithFile, getURISafePathFromArray } from "../../../Utils/pathUtils"
+import { extractFileBrowserPathFromURL, getPathWithFile, getUrlSafePathWithFile } from "../../../Utils/pathUtils"
 import { ROUTE_LINKS } from "../../FilesRoutes"
 import { FileBrowserContext } from "../../../Contexts/FileBrowserContext"
 import { useFilesApi } from "../../../Contexts/FilesApiContext"
@@ -134,11 +134,7 @@ const BinFileBrowser: React.FC<IFileBrowserModuleProps> = ({ controls = false }:
   const viewFolder = useCallback((cid: string) => {
     const fileSystemItem = pathContents.find(f => f.cid === cid)
     if (fileSystemItem && fileSystemItem.content_type === CONTENT_TYPES.Directory) {
-      let urlSafePath =  getURISafePathFromArray(getArrayOfPaths(currentPath))
-      if (urlSafePath === "/") {
-        urlSafePath = ""
-      }
-      redirect(ROUTE_LINKS.Bin(`${urlSafePath}/${encodeURIComponent(`${fileSystemItem.name}`)}`))
+      redirect(ROUTE_LINKS.Bin(getUrlSafePathWithFile(currentPath, fileSystemItem.name)))
     }
   }, [currentPath, pathContents, redirect])
 

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/CSFFileBrowser.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/CSFFileBrowser.tsx
@@ -1,7 +1,13 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react"
 import { Crumb, useToaster, useHistory, useLocation } from "@chainsafe/common-components"
 import { useFiles, FileSystemItem } from "../../../Contexts/FilesContext"
-import { getArrayOfPaths, getURISafePathFromArray, getPathWithFile, extractFileBrowserPathFromURL } from "../../../Utils/pathUtils"
+import {
+  getArrayOfPaths,
+  getURISafePathFromArray,
+  getPathWithFile,
+  extractFileBrowserPathFromURL,
+  getUrlSafePathWithFile
+} from "../../../Utils/pathUtils"
 import { IBulkOperations, IFileBrowserModuleProps, IFilesTableBrowserProps } from "./types"
 import FilesList from "./views/FilesList"
 import { CONTENT_TYPES } from "../../../Utils/Constants"
@@ -191,11 +197,7 @@ const CSFFileBrowser: React.FC<IFileBrowserModuleProps> = () => {
   const viewFolder = useCallback((cid: string) => {
     const fileSystemItem = pathContents.find(f => f.cid === cid)
     if (fileSystemItem && fileSystemItem.content_type === CONTENT_TYPES.Directory) {
-      let urlSafePath =  getURISafePathFromArray(getArrayOfPaths(currentPath))
-      if (urlSafePath === "/") {
-        urlSafePath = ""
-      }
-      redirect(ROUTE_LINKS.Drive(`${urlSafePath}/${encodeURIComponent(`${fileSystemItem.name}`)}`))
+      redirect(ROUTE_LINKS.Drive(getUrlSafePathWithFile(currentPath, fileSystemItem.name)))
     }
   }, [currentPath, pathContents, redirect])
 

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/CreateFolderModal.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/CreateFolderModal.tsx
@@ -13,11 +13,12 @@ import React, { useRef, useEffect, useState } from "react"
 import { Formik, Form } from "formik"
 import CustomModal from "../../Elements/CustomModal"
 import CustomButton from "../../Elements/CustomButton"
-import { Trans } from "@lingui/macro"
+import { t, Trans } from "@lingui/macro"
 import { CSFTheme } from "../../../Themes/types"
 import { useFileBrowser } from "../../../Contexts/FileBrowserContext"
 import { useFilesApi } from "../../../Contexts/FilesApiContext"
 import { folderNameValidator } from "../../../Utils/validationSchema"
+import { getPathWithFile } from "../../../Utils/pathUtils"
 
 
 const useStyles = makeStyles(
@@ -114,7 +115,7 @@ const CreateFolderModal: React.FC<ICreateFolderModalProps> = ({
           helpers.setSubmitting(true)
           try {
             setCreatingFolder(true)
-            await filesApiClient.addBucketDirectory(bucket.id, { path: `${currentPath}/${values.name}` })
+            await filesApiClient.addBucketDirectory(bucket.id, { path: getPathWithFile(currentPath, values.name.trim()) })
             refreshContents && await refreshContents()
             setCreatingFolder(false)
             helpers.resetForm()
@@ -122,7 +123,7 @@ const CreateFolderModal: React.FC<ICreateFolderModalProps> = ({
           } catch (errors) {
             setCreatingFolder(false)
             if (errors[0].message.includes("Entry with such name can")) {
-              helpers.setFieldError("name", "Folder name is already in use")
+              helpers.setFieldError("name", t`Folder name is already in use`)
             } else {
               helpers.setFieldError("name", errors[0].message)
             }

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/SharedFileBrowser.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/SharedFileBrowser.tsx
@@ -1,6 +1,12 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react"
 import { useToaster, useHistory, useLocation, Crumb } from "@chainsafe/common-components"
-import { getArrayOfPaths, getURISafePathFromArray, getPathWithFile, extractSharedFileBrowserPathFromURL } from "../../../Utils/pathUtils"
+import {
+  getArrayOfPaths,
+  getURISafePathFromArray,
+  getPathWithFile,
+  extractSharedFileBrowserPathFromURL,
+  getUrlSafePathWithFile
+} from "../../../Utils/pathUtils"
 import { IBulkOperations, IFilesTableBrowserProps } from "./types"
 import { CONTENT_TYPES } from "../../../Utils/Constants"
 import { t } from "@lingui/macro"
@@ -164,11 +170,7 @@ const SharedFileBrowser = () => {
 
     const fileSystemItem = pathContents.find(f => f.cid === cid)
     if (fileSystemItem && fileSystemItem.content_type === CONTENT_TYPES.Directory) {
-      let urlSafePath =  getURISafePathFromArray(getArrayOfPaths(currentPath))
-      if (urlSafePath === "/") {
-        urlSafePath = ""
-      }
-      redirect(ROUTE_LINKS.SharedFolderExplorer(bucket.id, `${urlSafePath}/${encodeURIComponent(`${fileSystemItem.name}`)}`))
+      redirect(ROUTE_LINKS.SharedFolderExplorer(bucket.id, getUrlSafePathWithFile(currentPath, fileSystemItem.name)))
     }
   }, [currentPath, pathContents, redirect, bucket])
 

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/views/FileSystemItem/FileSystemItem.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/views/FileSystemItem/FileSystemItem.tsx
@@ -177,7 +177,7 @@ const FileSystemItem = ({
 
   const { desktop } = useThemeSwitcher()
   const classes = useStyles()
-  const filePath = useMemo(() => `${currentPath}/${name}`, [currentPath, name])
+  const filePath = useMemo(() => getPathWithFile(currentPath, name), [currentPath, name])
 
   const onFilePreview = useCallback(() => {
     showPreview && showPreview(files.indexOf(file))

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/views/FileSystemItem/FileSystemItem.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/views/FileSystemItem/FileSystemItem.tsx
@@ -355,7 +355,7 @@ const FileSystemItem = ({
     accept: [NativeTypes.FILE],
     drop: (item: any) => {
       handleUploadOnDrop &&
-        handleUploadOnDrop(item.files, item.items, `${currentPath}${name}`)
+        handleUploadOnDrop(item.files, item.items, getPathWithFile(currentPath, name))
     },
     collect: (monitor) => ({
       isOverUpload: monitor.isOver()

--- a/packages/files-ui/src/Contexts/FilesContext.tsx
+++ b/packages/files-ui/src/Contexts/FilesContext.tsx
@@ -20,6 +20,7 @@ import { useBeforeunload } from "react-beforeunload"
 import { useThresholdKey } from "./ThresholdKeyContext"
 import { useFilesApi } from "./FilesApiContext"
 import { useUser } from "./UserContext"
+import { getPathWithFile } from "../Utils/pathUtils"
 
 type FilesContextProps = {
   children: React.ReactNode | React.ReactNode[]
@@ -464,7 +465,7 @@ const FilesProvider = ({ children }: FilesContextProps) => {
       const result = await getFileContent(bucketId, {
         cid: itemToDownload.cid,
         file: itemToDownload,
-        path: `${path}/${itemToDownload.name}`,
+        path: getPathWithFile(path, itemToDownload.name),
         onDownloadProgress: (progressEvent) => {
           dispatchDownloadsInProgress({
             type: "progress",

--- a/packages/files-ui/src/Utils/pathUtils.ts
+++ b/packages/files-ui/src/Utils/pathUtils.ts
@@ -86,3 +86,12 @@ export const isSubFolder = (fold1: string, fold2: string) => {
 
   return result
 }
+
+export const getUrlSafePathWithFile = (path: string, fileName: string) => {
+  let urlSafePath =  getURISafePathFromArray(getArrayOfPaths(path))
+  if (urlSafePath === "/") {
+    urlSafePath = ""
+  }
+
+  return `${urlSafePath}/${encodeURIComponent(fileName)}`
+}

--- a/packages/files-ui/src/locales/de/messages.po
+++ b/packages/files-ui/src/locales/de/messages.po
@@ -292,6 +292,9 @@ msgstr "Ordner"
 msgid "Folder name cannot only contain whitepsace characters"
 msgstr ""
 
+msgid "Folder name is already in use"
+msgstr ""
+
 msgid "Folders"
 msgstr "Ordner"
 

--- a/packages/files-ui/src/locales/en/messages.po
+++ b/packages/files-ui/src/locales/en/messages.po
@@ -295,6 +295,9 @@ msgstr "Folder"
 msgid "Folder name cannot only contain whitepsace characters"
 msgstr "Folder name cannot only contain whitepsace characters"
 
+msgid "Folder name is already in use"
+msgstr "Folder name is already in use"
+
 msgid "Folders"
 msgstr "Folders"
 

--- a/packages/files-ui/src/locales/es/messages.po
+++ b/packages/files-ui/src/locales/es/messages.po
@@ -296,6 +296,9 @@ msgstr "Archivo"
 msgid "Folder name cannot only contain whitepsace characters"
 msgstr ""
 
+msgid "Folder name is already in use"
+msgstr ""
+
 msgid "Folders"
 msgstr "Archivos"
 

--- a/packages/files-ui/src/locales/fr/messages.po
+++ b/packages/files-ui/src/locales/fr/messages.po
@@ -296,6 +296,9 @@ msgstr "Dossier"
 msgid "Folder name cannot only contain whitepsace characters"
 msgstr ""
 
+msgid "Folder name is already in use"
+msgstr ""
+
 msgid "Folders"
 msgstr "Dossiers"
 

--- a/packages/files-ui/src/locales/no/messages.po
+++ b/packages/files-ui/src/locales/no/messages.po
@@ -292,6 +292,9 @@ msgstr "Mappe"
 msgid "Folder name cannot only contain whitepsace characters"
 msgstr ""
 
+msgid "Folder name is already in use"
+msgstr ""
+
 msgid "Folders"
 msgstr "Mapper"
 

--- a/packages/storage-ui/src/Components/Modules/CreateFolderModal/CreateFolderModal.tsx
+++ b/packages/storage-ui/src/Components/Modules/CreateFolderModal/CreateFolderModal.tsx
@@ -18,6 +18,7 @@ import { CSSTheme } from "../../../Themes/types"
 import { useFileBrowser } from "../../../Contexts/FileBrowserContext"
 import { useStorageApi } from "../../../Contexts/StorageApiContext"
 import { folderNameValidator } from "../../../Utils/validationSchema"
+import { getPathWithFile } from "../../../Utils/pathUtils"
 
 
 const useStyles = makeStyles(
@@ -114,7 +115,7 @@ const CreateFolderModal: React.FC<ICreateFolderModalProps> = ({
           helpers.setSubmitting(true)
           try {
             setCreatingFolder(true)
-            await storageApiClient.addBucketDirectory(bucket.id, { path: `${currentPath}/${values.name.trim()}` })
+            await storageApiClient.addBucketDirectory(bucket.id, { path: getPathWithFile(currentPath, values.name.trim()) })
             refreshContents && await refreshContents()
             setCreatingFolder(false)
             helpers.resetForm()

--- a/packages/storage-ui/src/Components/Modules/FileSystemItem/FileSystemItem.tsx
+++ b/packages/storage-ui/src/Components/Modules/FileSystemItem/FileSystemItem.tsx
@@ -229,7 +229,7 @@ const FileSystemItem = ({
           </span>
         </>
       ),
-      onClick: () => setFileInfoPath(`${currentPath}${name}`)
+      onClick: () => setFileInfoPath(getPathWithFile(currentPath, name))
     },
     recover: {
       contents: (
@@ -317,7 +317,7 @@ const FileSystemItem = ({
     accept: [NativeTypes.FILE],
     drop: (item: any) => {
       handleUploadOnDrop &&
-        handleUploadOnDrop(item.files, item.items, `${currentPath}${name}`)
+        handleUploadOnDrop(item.files, item.items, getPathWithFile(currentPath, name))
     },
     collect: (monitor) => ({
       isOverUpload: monitor.isOver()

--- a/packages/storage-ui/src/Components/Pages/BucketPage.tsx
+++ b/packages/storage-ui/src/Components/Pages/BucketPage.tsx
@@ -1,7 +1,13 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react"
 import { Crumb, useToaster, useHistory, useLocation } from "@chainsafe/common-components"
 import { useStorage, FileSystemItem } from "../../Contexts/StorageContext"
-import { getArrayOfPaths, getURISafePathFromArray, getPathWithFile, extractFileBrowserPathFromURL } from "../../Utils/pathUtils"
+import {
+  getArrayOfPaths,
+  getURISafePathFromArray,
+  getPathWithFile,
+  extractFileBrowserPathFromURL,
+  getUrlSafePathWithFile
+} from "../../Utils/pathUtils"
 import { IBulkOperations, IFileBrowserModuleProps, IFilesTableBrowserProps } from "../../Contexts/types"
 import FilesList from "../Modules/FilesList/FilesList"
 import { CONTENT_TYPES } from "../../Utils/Constants"
@@ -173,11 +179,8 @@ const BucketPage: React.FC<IFileBrowserModuleProps> = () => {
   const viewFolder = useCallback((toView: ISelectedFile) => {
     const fileSystemItem = pathContents.find(f => f.cid === toView.cid && f.name === toView.name)
     if (fileSystemItem && fileSystemItem.content_type === CONTENT_TYPES.Directory) {
-      let urlSafePath =  getURISafePathFromArray(getArrayOfPaths(currentPath))
-      if (urlSafePath === "/") {
-        urlSafePath = ""
-      }
-      redirect(ROUTE_LINKS.Bucket(bucketId, `${urlSafePath}/${encodeURIComponent(`${fileSystemItem.name}`)}`))
+
+      redirect(ROUTE_LINKS.Bucket(bucketId, getUrlSafePathWithFile(currentPath, fileSystemItem.name)))
     }
   }, [currentPath, pathContents, redirect, bucketId])
 

--- a/packages/storage-ui/src/Utils/pathUtils.ts
+++ b/packages/storage-ui/src/Utils/pathUtils.ts
@@ -83,3 +83,12 @@ export const isSubFolder = (fold1: string, fold2: string) => {
 
   return result
 }
+
+export const getUrlSafePathWithFile = (path: string, fileName: string) => {
+  let urlSafePath =  getURISafePathFromArray(getArrayOfPaths(path))
+  if (urlSafePath === "/") {
+    urlSafePath = ""
+  }
+
+  return `${urlSafePath}/${encodeURIComponent(fileName)}`
+}


### PR DESCRIPTION
- enforce the use of `getPathWithFile`
- create a `getSafePAthUrlWithFiles` to prevent duplication