### PR TITLE
Prevent double opening of the file picker

### DIFF
--- a/packages/common-components/src/FileInput/FileInput.tsx
+++ b/packages/common-components/src/FileInput/FileInput.tsx
@@ -265,7 +265,6 @@ const FileInput = ({
       {value?.length > 0 && (
         <div
           className={clsx(classes.addFiles, classNames?.addFiles)}
-          onClick={open}
         >
           <PlusIcon
             fontSize="small"


### PR DESCRIPTION
closes #1506

Small change long research :D
The why this happened: The dropzone area is overlapping with this button. When clicking on the button, both the `onclick` and then the dropzone called the file picker. Removing the `onclick` leave the dropzone handle this correctly for Brave and Firefox. It seems that FF had a prevent default when 2 click areas overlap, not Brave/Chrome.