### PR TITLE
Add "maintenance" label to weblate PRs automatically

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,3 +1,3 @@
 "Type: Feature": ['feature/*', 'feat/*']
 "Type: Bug Fix": fix/*
-"Type: Maintenance": ['chore/*', 'mnt/*']
+"Type: Maintenance": ['chore/*', 'mnt/*', 'weblate*']


### PR DESCRIPTION
This will prevent all the weblate PRs to end up being unspecified in the release changelog.