### PR TITLE
Fix `crypto` node resolve warning on common components

### DIFF
--- a/packages/common-components/rollup.config.js
+++ b/packages/common-components/rollup.config.js
@@ -20,7 +20,7 @@ export default {
   plugins: [
     peerDepsExternal(),
     image(),
-    resolve(),
+    resolve({ browser: true }),
     commonjs(),
     typescript(),
     postcss({


### PR DESCRIPTION
This PR is a fix for the `crypto` `preferBuiltins` warning.
Basically the nodeResolve tells that the uuid package is running on browser environment and uses web crypto API.
[reference](https://stackoverflow.com/questions/59937658/importing-uuid-in-rollup-esm-library-creates-an-import-statement-for-crypto-in)

<img width="431" alt="Screenshot 2021-10-05 at 10 10 33 PM" src="https://user-images.githubusercontent.com/10713353/136061559-5ec80043-ef6b-4167-953d-53cc827e05fe.png">

