### PR TITLE
[Files] Fix survey banner and sharing explainer

### DIFF
--- a/packages/files-ui/src/Components/Modules/FileBrowsers/CSFFileBrowser.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/CSFFileBrowser.tsx
@@ -34,6 +34,8 @@ const CSFFileBrowser: React.FC<IFileBrowserModuleProps> = () => {
   const { pathname } = useLocation()
   const currentPath = useMemo(() => extractFileBrowserPathFromURL(pathname, ROUTE_LINKS.Drive("")), [pathname])
   const bucket = useMemo(() => buckets.find(b => b.type === "csf"), [buckets])
+  const { profile, localStore } = useUser()
+  const [showSurvey, setShowSurvey] = useState(false)
 
   const refreshContents = useCallback((showLoading?: boolean) => {
     if (!bucket) return
@@ -50,10 +52,6 @@ const CSFFileBrowser: React.FC<IFileBrowserModuleProps> = () => {
       }).finally(() => showLoading && setLoadingCurrentPath(false))
   }, [bucket, filesApiClient, currentPath])
 
-  const { profile, localStore, setLocalStore } = useUser()
-
-  const showSurvey = localStore && localStore[DISMISSED_SURVEY_KEY] === "false"
-
   const olderThanOneWeek = useMemo(
     () => profile?.createdAt
       ? dayjs(Date.now()).diff(profile.createdAt, "day") > 7
@@ -62,11 +60,14 @@ const CSFFileBrowser: React.FC<IFileBrowserModuleProps> = () => {
   )
 
   useEffect(() => {
-    const dismissedFlag = localStore && localStore[DISMISSED_SURVEY_KEY]
-    if (dismissedFlag === undefined || dismissedFlag === null) {
-      setLocalStore({ [DISMISSED_SURVEY_KEY]: "false" }, "update")
+    if (!localStore) {
+      return
     }
-  }, [localStore, setLocalStore])
+
+    if (localStore[DISMISSED_SURVEY_KEY] === "false"){
+      setShowSurvey(true)
+    }
+  }, [localStore])
 
   useEffect(() => {
     refreshContents(true)

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/SharedFoldersOverview.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/SharedFoldersOverview.tsx
@@ -267,7 +267,7 @@ const SharedFolderOverview = () => {
         )}
       </article>
       <SharingExplainerModal
-        showModal={hasSeenSharingExplainerModal}
+        showModal={!hasSeenSharingExplainerModal}
         onHide={hideModal}
       />
       <CreateOrEditSharedFolderModal

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/hooks/useSharingExplainerModalFlag.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/hooks/useSharingExplainerModalFlag.tsx
@@ -6,22 +6,20 @@ export const DISMISSED_SHARING_EXPLAINER_KEY = "csf.dismissedSharingExplainer"
 
 export const useSharingExplainerModalFlag = () => {
   const { localStore, setLocalStore } = useUser()
-  const [hasSeenSharingExplainerModal, setHasSeenSharingExplainerModal] = useState(false)
-  const dismissedFlag = localStore ? localStore[DISMISSED_SHARING_EXPLAINER_KEY] : null
-
+  const [hasSeenSharingExplainerModal, setHasSeenSharingExplainerModal] = useState(true)
   useEffect(() => {
-    if (dismissedFlag === "false"){
-      setHasSeenSharingExplainerModal(true)
-    } else if (dismissedFlag === null) {
-      // the dismiss flag was never set
-      setLocalStore({ [DISMISSED_SHARING_EXPLAINER_KEY]: "false" }, "update")
-      setHasSeenSharingExplainerModal(true)
+    if (!localStore) {
+      return
     }
-  }, [dismissedFlag, setLocalStore])
+
+    if (localStore[DISMISSED_SHARING_EXPLAINER_KEY] === "false"){
+      setHasSeenSharingExplainerModal(false)
+    }
+  }, [localStore, setLocalStore])
 
   const hideModal = useCallback(() => {
     setLocalStore({ [DISMISSED_SHARING_EXPLAINER_KEY]: "true" }, "update")
-    setHasSeenSharingExplainerModal(false)
+    setHasSeenSharingExplainerModal(true)
   }, [setLocalStore])
 
   return { hasSeenSharingExplainerModal, hideModal }

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/views/FilesList.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/views/FilesList.tsx
@@ -348,7 +348,7 @@ const FilesList = ({ isShared = false }: Props) => {
   const { hasSeenSharingExplainerModal, hideModal } = useSharingExplainerModalFlag()
   const [hasClickedShare, setClickedShare] = useState(false)
   const showExplainerBeforeShare = useMemo(() =>
-    hasSeenSharingExplainerModal && hasClickedShare
+    !hasSeenSharingExplainerModal && hasClickedShare
   , [hasClickedShare, hasSeenSharingExplainerModal]
   )
   const items: FileSystemItemType[] = useMemo(() => {
@@ -616,9 +616,10 @@ const FilesList = ({ isShared = false }: Props) => {
     setIsDeleteModalOpen(true)
   }, [])
 
-  const handleOpenShareDialog = useCallback((e: React.MouseEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
+  const handleOpenShareDialog = useCallback((e?: React.MouseEvent) => {
+    e?.preventDefault()
+    e?.stopPropagation()
+    setClickedShare(true)
     setIsShareModalOpen(true)
   }, [])
 
@@ -649,13 +650,9 @@ const FilesList = ({ isShared = false }: Props) => {
   [classes.menuIcon])
 
   const onShare = useCallback((fileSystemItem: FileSystemItemType) => {
-    if(hasSeenSharingExplainerModal) {
-      setClickedShare(true)
-    }
-
     setSelectedItems([fileSystemItem])
-    setIsShareModalOpen(true)
-  }, [hasSeenSharingExplainerModal])
+    handleOpenShareDialog()
+  }, [handleOpenShareDialog])
 
   return (
     <article

--- a/packages/files-ui/src/Components/SharingExplainerModal.tsx
+++ b/packages/files-ui/src/Components/SharingExplainerModal.tsx
@@ -132,9 +132,9 @@ const SharingExplainerModal = ({ showModal, onHide }: Props) => {
       return
     } else {
       switch (next) {
-        case 3:
+        case STEP_NUMBER:
           setLocalStore({ [DISMISSED_SHARING_EXPLAINER_KEY]:  "true" }, "update")
-          setStep(3)
+          setStep(STEP_NUMBER)
           break
         case STEP_NUMBER + 1:
           onHide()

--- a/packages/files-ui/src/Components/SurveyBanner.tsx
+++ b/packages/files-ui/src/Components/SurveyBanner.tsx
@@ -62,7 +62,7 @@ const SurveyBanner = ({ onHide }: Props) => {
     setLocalStore({ [DISMISSED_SURVEY_KEY]: "true" }, "update")
   }, [setLocalStore, onHide])
 
-  const onOpen = useCallback(() => {
+  const onOpenLink = useCallback(() => {
     onClose()
     window.open(ROUTE_LINKS.UserSurvey, "_blank")
   }, [onClose])
@@ -77,7 +77,7 @@ const SurveyBanner = ({ onHide }: Props) => {
         </Trans>
         <span
           className={classes.link}
-          onClick={onOpen}
+          onClick={onOpenLink}
         >
           <Trans>Schedule a 15 min call</Trans>
         </span>

--- a/packages/files-ui/src/Contexts/UserContext.tsx
+++ b/packages/files-ui/src/Contexts/UserContext.tsx
@@ -82,6 +82,20 @@ const UserProvider = ({ children }: UserContextProps) => {
     }
   }, [filesApiClient])
 
+  const initLocalStore = useCallback((apiStore: ILocalStore | undefined) => {
+    let initStore = apiStore || {}
+
+    if (apiStore?.[DISMISSED_SHARING_EXPLAINER_KEY] === undefined) {
+      initStore = { ...initStore, [DISMISSED_SHARING_EXPLAINER_KEY]: "false" }
+    }
+
+    if (apiStore?.[DISMISSED_SURVEY_KEY] === undefined) {
+      initStore = { ...initStore, [DISMISSED_SURVEY_KEY]: "false" }
+    }
+
+    _setLocalStore(initStore)
+  }, [])
+
   useEffect(() => {
     if (!isLoggedIn) {
       return
@@ -89,23 +103,13 @@ const UserProvider = ({ children }: UserContextProps) => {
 
     filesApiClient.getUserLocalStore()
       .then((apiStore) => {
-        let initStore = apiStore
-
-        if (apiStore[DISMISSED_SHARING_EXPLAINER_KEY] === undefined) {
-          initStore = { ...initStore, [DISMISSED_SHARING_EXPLAINER_KEY]: "false" }
-        }
-
-        if (apiStore[DISMISSED_SURVEY_KEY] === undefined) {
-          initStore = { ...initStore, [DISMISSED_SURVEY_KEY]: "false" }
-        }
-
-        _setLocalStore(initStore)
+        initLocalStore(apiStore)
       })
       .catch((e) => {
         console.error(e)
-        _setLocalStore({})
+        initLocalStore({})
       })
-  }, [isLoggedIn, filesApiClient])
+  }, [isLoggedIn, filesApiClient, initLocalStore])
 
   useEffect(() => {
     if (!isLoggedIn) {

--- a/packages/files-ui/src/Contexts/UserContext.tsx
+++ b/packages/files-ui/src/Contexts/UserContext.tsx
@@ -3,6 +3,8 @@ import { useCallback, useEffect } from "react"
 import { useFilesApi } from "./FilesApiContext"
 import { useState } from "react"
 import { t } from "@lingui/macro"
+import { DISMISSED_SHARING_EXPLAINER_KEY } from "../Components/Modules/FileBrowsers/hooks/useSharingExplainerModalFlag"
+import { DISMISSED_SURVEY_KEY } from "../Components/SurveyBanner"
 
 type UserContextProps = {
   children: React.ReactNode | React.ReactNode[]
@@ -43,7 +45,6 @@ const UserContext = React.createContext<IUserContext | undefined>(undefined)
 
 const UserProvider = ({ children }: UserContextProps) => {
   const { filesApiClient, isLoggedIn } = useFilesApi()
-
   const [profile, setProfile] = useState<Profile | undefined>(undefined)
   const [localStore, _setLocalStore] = useState<ILocalStore | undefined>()
 
@@ -86,7 +87,19 @@ const UserProvider = ({ children }: UserContextProps) => {
     }
 
     filesApiClient.getUserLocalStore()
-      .then(_setLocalStore)
+      .then((apiStore) => {
+        let initStore = apiStore
+
+        if (apiStore[DISMISSED_SHARING_EXPLAINER_KEY] === undefined) {
+          initStore = { ...initStore, [DISMISSED_SHARING_EXPLAINER_KEY]: "false" }
+        }
+
+        if (apiStore[DISMISSED_SURVEY_KEY] === undefined) {
+          initStore = { ...initStore, [DISMISSED_SURVEY_KEY]: "false" }
+        }
+
+        _setLocalStore(initStore)
+      })
       .catch((e) => {
         console.error(e)
         _setLocalStore({})


### PR DESCRIPTION
closes #1617
- fixes the survey banner that most prob. didn't work well either
- shows the sharing explainer before bulk-sharing

To test, you can add for instance in `SharedFolderOverview` something like this to have 2 buttons to reset the store values
```js
import { DISMISSED_SHARING_EXPLAINER_KEY } from "./hooks/useSharingExplainerModalFlag"
import { DISMISSED_SURVEY_KEY } from "../../SurveyBanner"
import { useUser } from "../../../Contexts/UserContext"

const { setLocalStore } = useUser()

<button onClick={() => setLocalStore({ [DISMISSED_SHARING_EXPLAINER_KEY]: "false" }, "update")}>setExplainer to false</button>
<button onClick={() => setLocalStore({ [DISMISSED_SURVEY_KEY]: "false" }, "update")}>setSurvey to false</button>
```