### PR TITLE
Hide network requests from cypress test runner

### DIFF
--- a/packages/files-ui/cypress/support/index.ts
+++ b/packages/files-ui/cypress/support/index.ts
@@ -28,5 +28,19 @@ Cypress.on("uncaught:exception", (err) => {
   }
 })
 
+// Hide fetch/XHR requests
+// interim solution until cypress adds configuration support
+// source https://gist.github.com/simenbrekken/3d2248f9e50c1143bf9dbe02e67f5399
+const app = window.top
+
+if(app != null && !app.document.head.querySelector("[data-hide-command-log-request]")) {
+  const style = app.document.createElement("style")
+  style.innerHTML =
+    ".command-name-request, .command-name-xhr { display: none }"
+  style.setAttribute("data-hide-command-log-request", "")
+
+  app.document.head.appendChild(style)
+}
+
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/packages/files-ui/cypress/support/page-objects/toasts/recoverSuccessToast.ts
+++ b/packages/files-ui/cypress/support/page-objects/toasts/recoverSuccessToast.ts
@@ -1,0 +1,4 @@
+export const recoverSuccessToast = {
+  body: () => cy.get("[data-testId=toast-recover-success]", { timeout: 10000 }),
+  closeButton: () => cy.get("[data-testid=button-close-toast-recover-success]")
+}

--- a/packages/files-ui/cypress/tests/file-management-spec.ts
+++ b/packages/files-ui/cypress/tests/file-management-spec.ts
@@ -11,6 +11,7 @@ import { moveItemModal } from "../support/page-objects/modals/moveItemModal"
 import { recoverItemModal } from "../support/page-objects/modals/recoverItemModal"
 import { deleteSuccessToast } from "../support/page-objects/toasts/deleteSuccessToast"
 import { moveSuccessToast } from "../support/page-objects/toasts/moveSuccessToast"
+import { recoverSuccessToast } from "../support/page-objects/toasts/recoverSuccessToast"
 import { uploadCompleteToast } from "../support/page-objects/toasts/uploadCompleteToast"
 
 describe("File management", () => {
@@ -89,12 +90,16 @@ describe("File management", () => {
 
         // ensure the home root now has the folder and file
         navigationMenu.homeNavButton().click()
-        homePage.fileItemRow().should("have.length", 2)
+        homePage.fileItemRow()
+          .should("be.visible")
+          .should("have.length", 2)
         homePage.fileItemName().should("contain.text", folderName)
         homePage.fileItemName().should("contain.text", $fileName)
 
-        // ensure folder already in the root cannot be moved to Home
-        homePage.fileItemName().contains(`${$fileName}`).click()
+        // ensure file already in the root cannot be moved to Home
+        homePage.fileItemName().contains(`${$fileName}`)
+          .should("be.visible")
+          .click()
         homePage.moveSelectedButton().click()
         moveItemModal.folderList().contains("Home").click()
         moveItemModal.errorLabel().should("be.visible")
@@ -112,8 +117,10 @@ describe("File management", () => {
       // select a parent folder and initiate move action
       homePage.fileItemName().contains("Parent").click()
       homePage.moveSelectedButton().click()
+      moveItemModal.body().should("be.visible")
 
       // ensure folder already in the root cannot be moved to Home
+      moveItemModal.folderList().should("be.visible")
       moveItemModal.folderList().contains("Home").click()
       moveItemModal.body().should("be.visible")
       moveItemModal.errorLabel().should("be.visible")
@@ -259,6 +266,8 @@ describe("File management", () => {
       recoverItemModal.folderList().contains("Home").click()
       recoverItemModal.recoverButton().safeClick()
       binPage.fileItemRow().should("not.exist")
+      recoverSuccessToast.body().should("be.visible")
+      recoverSuccessToast.closeButton().click()
 
       // ensure recovered file is correct
       navigationMenu.homeNavButton().click()

--- a/packages/files-ui/cypress/tests/file-preview-spec.ts
+++ b/packages/files-ui/cypress/tests/file-preview-spec.ts
@@ -11,6 +11,7 @@ describe("File Preview", () => {
       // add files
       homePage.uploadFile("../fixtures/uploadedFiles/logo.png")
       homePage.uploadFile("../fixtures/uploadedFiles/text-file.txt")
+      homePage.fileItemRow().should("have.length", 2)
 
       // store their file names as cypress aliases for later comparison
       homePage.fileItemName().eq(0).invoke("text").as("fileNameA")

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/BinFileBrowser.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/BinFileBrowser.tsx
@@ -93,7 +93,8 @@ const BinFileBrowser: React.FC<IFileBrowserModuleProps> = ({ controls = false }:
     ).then(() => {
       addToast({
         title: t`Data restored successfully`,
-        type: "success"
+        type: "success",
+        testId: "recover-success"
       })
     }).catch((error) => {
       console.error("Error recovering:", error)


### PR DESCRIPTION
closes #1638

- Hides network requests in the window making the cypress test body readable again (interim fix until cypress has an official solution to filter the noise). 

- The tests appear to run faster now. After running the test suite multiple times and seeing some failures I needed to add a few extra checks to ensure that we're not trying to perform some actions too early. 