### PR TITLE
Link hover colors for secondary button

### DIFF
--- a/packages/common-components/src/Button/Button.tsx
+++ b/packages/common-components/src/Button/Button.tsx
@@ -93,7 +93,7 @@ const useStyles = makeStyles(
           fill: palette.common.white.main
         },
         "&:hover": {
-          backgroundColor: palette.primary.main,
+          backgroundColor: palette.primary.hover,
           color: palette.common.white.main,
           ...overrides?.Button?.variants?.secondary?.hover
         },

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/ReportFileModal.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/ReportFileModal.tsx
@@ -353,7 +353,7 @@ const ReportFileModal = ({ filePath, close }: IReportFileModalProps) => {
             <div className={clsx(classes.copiedFlag, { "active": copied })}>
               <span>
                 <Trans>
-                      Copied!
+                  Copied!
                 </Trans>
               </span>
             </div>


### PR DESCRIPTION
closes #1763 

Updated the hover state colors for `secondary` button, This also affects the buttons in login screen which use the `secondary` variant. 