### PR TITLE
Bring back signout menu on mobile

### DIFF
--- a/packages/files-ui/src/Components/Layouts/AppNav.tsx
+++ b/packages/files-ui/src/Components/Layouts/AppNav.tsx
@@ -293,7 +293,7 @@ const AppNav = ({ navOpen, setNavOpen }: IAppNav) => {
                   className={classes.menuItem}
                   menuItems={[
                     {
-                      onClick: () => signOut(),
+                      onClick: signOut,
                       contents: (
                         <div
                           data-cy="menu-sign-out"
@@ -332,9 +332,7 @@ const AppNav = ({ navOpen, setNavOpen }: IAppNav) => {
               <nav className={classes.navMenu}>
                 <Link
                   data-cy="link-home"
-                  onClick={() => {
-                    handleOnClick()
-                  }}
+                  onClick={handleOnClick}
                   className={classes.navItem}
                   to={ROUTE_LINKS.Drive("/")}
                 >
@@ -414,17 +412,31 @@ const AppNav = ({ navOpen, setNavOpen }: IAppNav) => {
                         size="small"
                       />
                     </>
-                  )
-                  }
+                  )}
                 </div>
               )}
               {!desktop && (
-                <div
-                  onClick={() => setNavOpen(false)}
-                  className={clsx(classes.blocker, {
-                    active: navOpen
-                  })}
-                ></div>
+                <>
+                  <div
+                    onClick={() => setNavOpen(false)}
+                    className={clsx(classes.blocker, {
+                      active: navOpen
+                    })}
+                  />
+                  <div
+                    data-cy="signout-nav"
+                    className={classes.navItem}
+                    onClick={() => {
+                      handleOnClick()
+                      signOut()
+                    }}
+                  >
+                    <PowerDownSvg />
+                    <Typography>
+                      <Trans>Sign Out</Trans>
+                    </Typography>
+                  </div>
+                </>
               )}
             </section>
           </>


### PR DESCRIPTION
This fixes the test

---

Submission checklist: 

<!-- Remove anything below that is not applicable -->   

#### Layout
- [x] Change looks good in the desktop web ui
- [x] Change looks good in the mobile web ui

#### Theme
- [x] Components / elements inspected in light mode 
- [x] Components / elements inspected in dark mode 