### PR TITLE
Fix React warning with data attributes

### DIFF
--- a/packages/common-components/src/Button/Button.tsx
+++ b/packages/common-components/src/Button/Button.tsx
@@ -356,7 +356,7 @@ const Button: React.FC<IButtonProps> = ({
       )}
       disabled={disabled || loading}
       {...rest}
-      data-testId={`button-${testId}`}
+      data-testid={`button-${testId}`}
     >
       {loading && (
         <>

--- a/packages/common-components/src/CheckboxInput/CheckboxInput.tsx
+++ b/packages/common-components/src/CheckboxInput/CheckboxInput.tsx
@@ -130,7 +130,7 @@ const CheckboxInput: React.FC<ICheckboxProps> = ({
   return (
     <label
       className={clsx(classes.root, className)}
-      data-testId={`checkbox-${testId}`}
+      data-testid={`checkbox-${testId}`}
     >
       <input
         type="checkbox"

--- a/packages/common-components/src/FileInput/FileInput.tsx
+++ b/packages/common-components/src/FileInput/FileInput.tsx
@@ -201,7 +201,7 @@ const FileInput = ({
   return (
     <div
       {...getRootProps()}
-      data-testId={`input-file-dropzone-${testId}`}
+      data-testid={`input-file-dropzone-${testId}`}
       className={clsx(classes.root, className)}
     >
       <input {...getInputProps()} />
@@ -220,7 +220,7 @@ const FileInput = ({
           </div>
         ) : (
           <div
-            data-testId={`list-${testId}`}
+            data-testid={`list-${testId}`}
             className={clsx(classes.root, classNames?.filelist)}
           >
             <ScrollbarWrapper className={clsx("scrollbar")}>

--- a/packages/common-components/src/HamburgerMenu/HamburgerMenu.tsx
+++ b/packages/common-components/src/HamburgerMenu/HamburgerMenu.tsx
@@ -111,7 +111,7 @@ const HamburgerMenu = ({
     <section
       onClick={onClick}
       className={clsx(classes.root, variant, className)}
-      data-testId={testId}
+      data-testid={testId}
     >
       <div className={classes.inner}>
         <span></span>

--- a/packages/common-components/src/MenuDropdown/MenuDropdown.tsx
+++ b/packages/common-components/src/MenuDropdown/MenuDropdown.tsx
@@ -264,7 +264,7 @@ const MenuDropdown = ({
       className={clsx(classes.root, className)}
     >
       <section
-        data-testId={`dropdown-title-${testId}`}
+        data-testid={`dropdown-title-${testId}`}
         onClick={() => setOpen(!open)}
         className={clsx(classes.title, classNames?.title, {
           ["open"]: open
@@ -295,7 +295,7 @@ const MenuDropdown = ({
       >
         {menuItems && menuItems.map((item: IMenuItem, index: number) => (
           <div
-            data-testId={`dropdown-item-${testId}`}
+            data-testid={`dropdown-item-${testId}`}
             key={`menu-${index}`}
             className={clsx(classes.item, classNames?.item)}
             onClick={() => {

--- a/packages/common-components/src/Modal/Modal.tsx
+++ b/packages/common-components/src/Modal/Modal.tsx
@@ -210,7 +210,7 @@ const Modal = ({
       ref={ref}
     >
       <section
-        data-testId={`modal-container-${testId}`}
+        data-testid={`modal-container-${testId}`}
         style={
           maxWidth && typeof maxWidth == "number"
             ? {

--- a/packages/common-components/src/SearchBar/SearchBar.tsx
+++ b/packages/common-components/src/SearchBar/SearchBar.tsx
@@ -227,7 +227,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
           value={value}
           placeholder={placeholder}
           onChange={onChange}
-          data-testId={testId}
+          data-testid={testId}
         />
         <div className={clsx(classes.standardIcon, size, "right")}>
           <Spinner

--- a/packages/common-components/src/Table/Table.tsx
+++ b/packages/common-components/src/Table/Table.tsx
@@ -91,7 +91,7 @@ const Table: React.FC<ITableProps> = ({
         },
         className
       )}
-      data-testId={`table-${testId}`}
+      data-testid={`table-${testId}`}
       {...rest}
     >
       {children}

--- a/packages/common-components/src/Tabs/Tabs.tsx
+++ b/packages/common-components/src/Tabs/Tabs.tsx
@@ -69,7 +69,7 @@ const Tabs = <TabKey, >({ className, children, activeKey, injectedClass, onTabSe
           ? children.map((elem, index) => {
             return (
               <li
-                data-testId={elem.props.testId}
+                data-testid={elem.props.testId}
                 key={index}
                 className={
                   clsx(

--- a/packages/common-components/src/Toasts/ToastContent.tsx
+++ b/packages/common-components/src/Toasts/ToastContent.tsx
@@ -87,7 +87,7 @@ const ToastContent = ({ toast, onClose }: ToastContentProps) => {
   return (
     <div
       className={clsx(classes.root)}
-      data-testId={`toast-${toast.testId}`}
+      data-testid={`toast-${toast.testId}`}
     >
       {progress !== undefined
         ? <>
@@ -141,7 +141,7 @@ const ToastContent = ({ toast, onClose }: ToastContentProps) => {
       }
       {isClosable &&
         <div
-          data-testId={`button-close-toast-${toast.testId}`}
+          data-testid={`button-close-toast-${toast.testId}`}
           className={classes.closeIcon}
           onClick={onClose}
         >

--- a/packages/files-ui/cypress/support/page-objects/basePage.ts
+++ b/packages/files-ui/cypress/support/page-objects/basePage.ts
@@ -2,11 +2,11 @@
 
 export const basePage = {
   appHeaderLabel: () => cy.get("[data-cy=label-files-app-header]", { timeout: 20000 }),
-  searchInput: () => cy.get("[data-testId=input-search-bar]"),
-  signOutDropdown: () => cy.get("[data-testId=dropdown-title-sign-out-dropdown]"),
+  searchInput: () => cy.get("[data-testid=input-search-bar]"),
+  signOutDropdown: () => cy.get("[data-testid=dropdown-title-sign-out-dropdown]"),
   signOutMenuOption: () => cy.get("[data-cy=menu-sign-out]"),
   // Mobile view only element
-  hamburgerMenuButton: () => cy.get("[data-testId=icon-hamburger-menu]"),
+  hamburgerMenuButton: () => cy.get("[data-testid=icon-hamburger-menu]"),
 
   // helpers and convenience functions
   awaitBucketRefresh() {

--- a/packages/files-ui/cypress/support/page-objects/binPage.ts
+++ b/packages/files-ui/cypress/support/page-objects/binPage.ts
@@ -6,9 +6,9 @@ export const binPage = {
   ...fileBrowser,
 
   // bin page specific file browser elements
-  recoverSelectedButton: () => cy.get("[data-testId=button-recover-selected-file]"),
-  deleteSelectedButton: () => cy.get("[data-testId=button-delete-selected-file]"),
-  selectAllCheckbox: () => cy.get("[data-testId=checkbox-select-all]"),
+  recoverSelectedButton: () => cy.get("[data-testid=button-recover-selected-file]"),
+  deleteSelectedButton: () => cy.get("[data-testid=button-delete-selected-file]"),
+  selectAllCheckbox: () => cy.get("[data-testid=checkbox-select-all]"),
 
   // kebab menu elements
   recoverMenuOption: () => cy.get("[data-cy=menu-recover]"),

--- a/packages/files-ui/cypress/support/page-objects/fileBrowser.ts
+++ b/packages/files-ui/cypress/support/page-objects/fileBrowser.ts
@@ -1,8 +1,8 @@
 export const fileBrowser = {
-  fileItemKebabButton: () => cy.get("[data-testId=icon-file-item-kebab]", { timeout: 10000 }),
+  fileItemKebabButton: () => cy.get("[data-testid=icon-file-item-kebab]", { timeout: 10000 }),
   fileItemName: () => cy.get("[data-cy=label-file-item-name]"),
   fileItemRow: () => cy.get("[data-cy=row-file-item]", { timeout: 20000 }),
-  fileTable: () => cy.get("[data-testId=table-home]"),
+  fileTable: () => cy.get("[data-testid=table-home]"),
   folderBreadcrumb: () => cy.get("[data-cy=breadcrumb-folder-navigation]"),
   noDataStateInfo: () => cy.get("[data-cy=container-no-files-data-state]")
 }

--- a/packages/files-ui/cypress/support/page-objects/homePage.ts
+++ b/packages/files-ui/cypress/support/page-objects/homePage.ts
@@ -12,9 +12,9 @@ export const homePage = {
   surveyBanner: () => cy.get("[data-cy=banner-survey]"),
   newFolderButton: () => cy.get("[data-cy=button-new-folder]"),
   uploadButton: () => cy.get("[data-cy=button-upload-file]"),
-  moveSelectedButton: () => cy.get("[data-testId=button-move-selected-file]"),
-  deleteSelectedButton: () => cy.get("[data-testId=button-delete-selected-file]"),
-  selectAllCheckbox: () => cy.get("[data-testId=checkbox-select-all]"),
+  moveSelectedButton: () => cy.get("[data-testid=button-move-selected-file]"),
+  deleteSelectedButton: () => cy.get("[data-testid=button-delete-selected-file]"),
+  selectAllCheckbox: () => cy.get("[data-testid=checkbox-select-all]"),
   fileRenameInput: () => cy.get("[data-cy=input-rename-file-or-folder]"),
   fileRenameErrorLabel: () => cy.get("[data-cy=form-rename] span.minimal.error"),
 

--- a/packages/files-ui/cypress/support/page-objects/modals/createSharedFolderModal.ts
+++ b/packages/files-ui/cypress/support/page-objects/modals/createSharedFolderModal.ts
@@ -1,5 +1,5 @@
 export const createEditSharedFolderModal = {
-  body: () => cy.get("[data-testId=modal-container-create-or-edit-shared-folder]", { timeout: 10000 }),
+  body: () => cy.get("[data-testid=modal-container-create-or-edit-shared-folder]", { timeout: 10000 }),
   cancelButton: () => cy.get("[data-cy=button-cancel-create-shared-folder]"),
   createButton: () => cy.get("[data-cy=button-create-shared-folder]", { timeout: 10000 }),
   editPermissionInput: () => cy.get("[data-cy=input-edit-permission]"),
@@ -14,9 +14,9 @@ export const createEditSharedFolderModal = {
   activeShareLink: () => cy.get("[data-cy=link-active-share]"),
   labelPermissionType: () => cy.get("[data-cy=label-permission-type]"),
   copyLinkButton: () => cy.get("[data-cy=button-copy-link]"),
-  linkKebabMenu: () => cy.get("[data-testId=icon-link-kebab]"),
+  linkKebabMenu: () => cy.get("[data-testid=icon-link-kebab]"),
   deleteLinkMenuOption: () => cy.get("[data-cy=menu-delete-active-link]"),
-  permissionTypeDropdown: () => cy.get("[data-testId=dropdown-title-permission]"),
+  permissionTypeDropdown: () => cy.get("[data-testid=dropdown-title-permission]"),
   viewOnlyDropdownOption: () => cy.get("[data-cy=menu-read]"),
   canEditDropdownOption: () => cy.get("[data-cy=menu-write]"),
   createLinkButton: () => cy.get("[data-cy=button-create-link]")

--- a/packages/files-ui/cypress/support/page-objects/modals/deleteFileModal.ts
+++ b/packages/files-ui/cypress/support/page-objects/modals/deleteFileModal.ts
@@ -1,5 +1,5 @@
 export const deleteFileModal = {
-  body: () => cy.get("[data-testId=modal-container-file-deletion]"),
-  cancelButton: () => cy.get("[data-testId=button-cancel-deletion]"),
-  confirmButton: () => cy.get("[data-testId=button-confirm-deletion]", { timeout: 10000 })
+  body: () => cy.get("[data-testid=modal-container-file-deletion]"),
+  cancelButton: () => cy.get("[data-testid=button-cancel-deletion]"),
+  confirmButton: () => cy.get("[data-testid=button-confirm-deletion]", { timeout: 10000 })
 }

--- a/packages/files-ui/cypress/support/page-objects/modals/deleteSharedFolderModal.ts
+++ b/packages/files-ui/cypress/support/page-objects/modals/deleteSharedFolderModal.ts
@@ -1,5 +1,5 @@
 export const deleteSharedFolderModal = {
-  body: () => cy.get("[data-testId=modal-container-shared-folder-deletion]"),
-  cancelButton: () => cy.get("[data-testId=button-cancel-deletion]"),
-  confirmButton: () => cy.get("[data-testId=button-confirm-deletion]", { timeout: 10000 })
+  body: () => cy.get("[data-testid=modal-container-shared-folder-deletion]"),
+  cancelButton: () => cy.get("[data-testid=button-cancel-deletion]"),
+  confirmButton: () => cy.get("[data-testid=button-confirm-deletion]", { timeout: 10000 })
 }

--- a/packages/files-ui/cypress/support/page-objects/modals/fileUploadModal.ts
+++ b/packages/files-ui/cypress/support/page-objects/modals/fileUploadModal.ts
@@ -1,8 +1,8 @@
 export const fileUploadModal = {
   body: () => cy.get("[data-cy=form-upload-file] input", { timeout: 20000 }),
-  cancelButton: () => cy.get("[data-testId=button-cancel-upload]"),
-  fileList: () => cy.get("[data-testId=list-fileUpload] li"),
-  removeFileButton: () => cy.get("[data-testId=button-remove-from-file-list]"),
-  uploadButton: () => cy.get("[data-testId=button-start-upload]", { timeout: 10000 }),
-  uploadDropzone : () => cy.get("[data-testId=input-file-dropzone-fileUpload]")
+  cancelButton: () => cy.get("[data-testid=button-cancel-upload]"),
+  fileList: () => cy.get("[data-testid=list-fileUpload] li"),
+  removeFileButton: () => cy.get("[data-testid=button-remove-from-file-list]"),
+  uploadButton: () => cy.get("[data-testid=button-start-upload]", { timeout: 10000 }),
+  uploadDropzone : () => cy.get("[data-testid=input-file-dropzone-fileUpload]")
 }

--- a/packages/files-ui/cypress/support/page-objects/modals/leaveSharedFolderModal.ts
+++ b/packages/files-ui/cypress/support/page-objects/modals/leaveSharedFolderModal.ts
@@ -1,5 +1,5 @@
 export const leaveSharedFolderModal = {
-  body: () => cy.get("[data-testId=modal-container-shared-folder-leave]"),
-  cancelButton: () => cy.get("[data-testId=button-cancel-deletion]"),
-  confirmButton: () => cy.get("[data-testId=button-confirm-deletion]", { timeout: 10000 })
+  body: () => cy.get("[data-testid=modal-container-shared-folder-leave]"),
+  cancelButton: () => cy.get("[data-testid=button-cancel-deletion]"),
+  confirmButton: () => cy.get("[data-testid=button-confirm-deletion]", { timeout: 10000 })
 }

--- a/packages/files-ui/cypress/support/page-objects/modals/moveItemModal.ts
+++ b/packages/files-ui/cypress/support/page-objects/modals/moveItemModal.ts
@@ -1,5 +1,5 @@
 export const moveItemModal = {
-  body: () => cy.get("[data-testId=modal-container-modal-move-file]"),
+  body: () => cy.get("[data-testid=modal-container-modal-move-file]"),
   cancelButton: () => cy.get("[data-cy=button-cancel-move]"),
   errorLabel: () => cy.get("[data-cy=label-move-file-error-message]"),
   folderList: () => cy.get("[data-cy=tree-folder-list]"),

--- a/packages/files-ui/cypress/support/page-objects/modals/previewModal.ts
+++ b/packages/files-ui/cypress/support/page-objects/modals/previewModal.ts
@@ -7,7 +7,7 @@ export const previewModal = {
   fileNameLabel: () => cy.get("[data-cy=label-previewed-file-name]"),
   fullScreenButton: () => cy.get("[data-cy=button-full-screen]"),
   nextFileButton: () => cy.get("[data-cy=button-view-next-file]"),
-  previewKebabButton: () => cy.get("[data-testId=icon-preview-kebab]"),
+  previewKebabButton: () => cy.get("[data-testid=icon-preview-kebab]"),
   previousFileButton: () => cy.get("[data-cy=button-view-previous-file]"),
   unsupportedFileLabel: () => cy.get("[data-cy=label-unsupported-file-message]", { timeout: 10000 }),
   ZoomInButton: () => cy.get("[data-cy=button-zoom-in]"),

--- a/packages/files-ui/cypress/support/page-objects/modals/recoverFileModal.ts
+++ b/packages/files-ui/cypress/support/page-objects/modals/recoverFileModal.ts
@@ -1,5 +1,5 @@
 export const recoverFileModal = {
-  body: () => cy.get("[data-testId=modal-container-modal-recover-file]"),
+  body: () => cy.get("[data-testid=modal-container-modal-recover-file]"),
   cancelButton: () => cy.get("[data-cy=button-cancel-recovery]"),
   errorLabel: () => cy.get("[data-cy=label-move-file-error-message]"),
   folderList: () => cy.get("[data-cy=tree-folder-list]"),

--- a/packages/files-ui/cypress/support/page-objects/modals/recoverItemModal.ts
+++ b/packages/files-ui/cypress/support/page-objects/modals/recoverItemModal.ts
@@ -1,5 +1,5 @@
 export const recoverItemModal = {
-  body: () => cy.get("[data-testId=modal-container-modal-recover-file]"),
+  body: () => cy.get("[data-testid=modal-container-modal-recover-file]"),
   cancelButton: () => cy.get("[data-cy=button-cancel-recovery]"),
   errorLabel: () => cy.get("[data-cy=label-move-file-error-message]"),
   folderList: () => cy.get("[data-cy=tree-folder-list]"),

--- a/packages/files-ui/cypress/support/page-objects/modals/sharingExplainerModal.ts
+++ b/packages/files-ui/cypress/support/page-objects/modals/sharingExplainerModal.ts
@@ -1,6 +1,6 @@
 export const sharingExplainerModal = {
-  body: () => cy.get("[data-testId=modal-container-sharing-explainer]"),
+  body: () => cy.get("[data-testid=modal-container-sharing-explainer]"),
   gotItButton: () => cy.get("[data-cy=button-got-it]"),
   nextButton: () => cy.get("[data-cy=button-next]"),
-  closeButton: () => cy.get("[data-testId=button-close-modal-sharing-explainer]")
+  closeButton: () => cy.get("[data-testid=button-close-modal-sharing-explainer]")
 }

--- a/packages/files-ui/cypress/support/page-objects/settingsPage.ts
+++ b/packages/files-ui/cypress/support/page-objects/settingsPage.ts
@@ -2,7 +2,7 @@ import { basePage } from "./basePage"
 
 export const settingsPage = {
   ...basePage,
-  profileTabButton: () => cy.get("[data-testId=tab-profile]"),
+  profileTabButton: () => cy.get("[data-testid=tab-profile]"),
   profileTabHeader: () => cy.get("[data-cy=label-profile-header]"),
   firstNameInput: () => cy.get("[data-cy=input-profile-firstname]"),
   lastNameInput: () => cy.get("[data-cy=input-profile-lastname]"),
@@ -12,7 +12,7 @@ export const settingsPage = {
   usernameErrorLabel: () => cy.get("[data-cy=input-profile-username] span.error"),
   setUsernameButton: () => cy.get("[data-cy=button-set-username]"),
   usernamePresentInput: () => cy.get("[data-cy=input-profile-username-present]"),
-  securityTabButton: () => cy.get("[data-testId=tab-security]"),
+  securityTabButton: () => cy.get("[data-testid=tab-security]"),
   securityTabHeader: () => cy.get("[data-cy=label-security-header]"),
-  subscriptionTabButton: () => cy.get("[data-testId=tab-subscription]")
+  subscriptionTabButton: () => cy.get("[data-testid=tab-subscription]")
 }

--- a/packages/files-ui/cypress/support/page-objects/toasts/deleteSuccessToast.ts
+++ b/packages/files-ui/cypress/support/page-objects/toasts/deleteSuccessToast.ts
@@ -1,4 +1,4 @@
 export const deleteSuccessToast = {
-  body: () => cy.get("[data-testId=toast-deletion-success]", { timeout: 10000 }),
-  closeButton: () => cy.get("[data-testId=button-close-toast-deletion-success]")
+  body: () => cy.get("[data-testid=toast-deletion-success]", { timeout: 10000 }),
+  closeButton: () => cy.get("[data-testid=button-close-toast-deletion-success]")
 }

--- a/packages/files-ui/cypress/support/page-objects/toasts/moveSuccessToast.ts
+++ b/packages/files-ui/cypress/support/page-objects/toasts/moveSuccessToast.ts
@@ -1,4 +1,4 @@
 export const moveSuccessToast = {
-  body: () => cy.get("[data-testId=toast-move-success]", { timeout: 10000 }),
-  closeButton: () => cy.get("[data-testId=button-close-toast-move-success]")
+  body: () => cy.get("[data-testid=toast-move-success]", { timeout: 10000 }),
+  closeButton: () => cy.get("[data-testid=button-close-toast-move-success]")
 }

--- a/packages/files-ui/cypress/support/page-objects/toasts/profileUpdateSuccessToast.ts
+++ b/packages/files-ui/cypress/support/page-objects/toasts/profileUpdateSuccessToast.ts
@@ -1,4 +1,4 @@
 export const profileUpdateSuccessToast = {
-  body: () => cy.get("[data-testId=toast-profile-update-success]", { timeout: 10000 }),
-  closeButton: () => cy.get("[data-testId=button-close-toast-profile-update-success]")
+  body: () => cy.get("[data-testid=toast-profile-update-success]", { timeout: 10000 }),
+  closeButton: () => cy.get("[data-testid=button-close-toast-profile-update-success]")
 }

--- a/packages/files-ui/cypress/support/page-objects/toasts/recoverSuccessToast.ts
+++ b/packages/files-ui/cypress/support/page-objects/toasts/recoverSuccessToast.ts
@@ -1,4 +1,4 @@
 export const recoverSuccessToast = {
-  body: () => cy.get("[data-testId=toast-recover-success]", { timeout: 10000 }),
-  closeButton: () => cy.get("[data-testId=button-close-toast-recover-success]")
+  body: () => cy.get("[data-testid=toast-recover-success]", { timeout: 10000 }),
+  closeButton: () => cy.get("[data-testid=button-close-toast-recover-success]")
 }

--- a/packages/files-ui/cypress/support/page-objects/toasts/uploadCompleteToast.ts
+++ b/packages/files-ui/cypress/support/page-objects/toasts/uploadCompleteToast.ts
@@ -1,4 +1,4 @@
 export const uploadCompleteToast = {
-  body: () => cy.get("[data-testId=toast-upload-complete]", { timeout: 10000 }),
-  closeButton: () => cy.get("[data-testId=button-close-toast-upload-complete]")
+  body: () => cy.get("[data-testid=toast-upload-complete]", { timeout: 10000 }),
+  closeButton: () => cy.get("[data-testid=button-close-toast-upload-complete]")
 }

--- a/packages/files-ui/src/UI-components/Menu.tsx
+++ b/packages/files-ui/src/UI-components/Menu.tsx
@@ -61,7 +61,7 @@ export default function Menu({ icon, options, style, testId, anchorOrigin, trans
   return (
     <div className={clsx(style?.menuWrapper)}>
       <div
-        data-testId={`icon-${testId}`}
+        data-testid={`icon-${testId}`}
         className={clsx(classes.iconContainer, style?.iconContainer)}
         onClick={handleClick}
       >

--- a/packages/storage-ui/cypress/support/page-objects/basePage.ts
+++ b/packages/storage-ui/cypress/support/page-objects/basePage.ts
@@ -1,8 +1,8 @@
 // Only add things here that could be applicable to all / most pages
 
 export const basePage = {
-  signOutDropdown: () => cy.get("[data-testId=dropdown-title-sign-out]"),
+  signOutDropdown: () => cy.get("[data-testid=dropdown-title-sign-out]"),
   signOutMenuOption: () => cy.get("[data-cy=menu-sign-out]"),
   // Mobile view only element
-  hamburgerMenuButton: () => cy.get("[data-testId=icon-hamburger-menu]")
+  hamburgerMenuButton: () => cy.get("[data-testid=icon-hamburger-menu]")
 }

--- a/packages/storage-ui/cypress/support/page-objects/bucketsPage.ts
+++ b/packages/storage-ui/cypress/support/page-objects/bucketsPage.ts
@@ -14,10 +14,10 @@ export const bucketsPage = {
   nameTableHeader: () => cy.get("[data-cy=table-header-name]"),
   sizeTableHeader: () => cy.get("[data-cy=table-header-size]"),
   bucketItemName: () => cy.get("[data-cy=cell-bucket-name]"),
-  bucketRowKebabButton: () => cy.get("[data-testId=dropdown-title-bucket-kebab]"),
+  bucketRowKebabButton: () => cy.get("[data-testid=dropdown-title-bucket-kebab]"),
 
   // create bucket modal elements
-  createBucketForm: () => cy.get("[data-testId=form-create-bucket]", { timeout: 10000 }),
+  createBucketForm: () => cy.get("[data-testid=form-create-bucket]", { timeout: 10000 }),
   bucketNameInput: () => cy.get("[data-cy=input-bucket-name]", { timeout: 10000 }),
   createBucketCancelButton: () => cy.get("[data-cy=button-cancel-create]"),
   createBucketSubmitButton: () => cy.get("[data-cy=button-submit-create]", { timeout: 10000 }),

--- a/packages/storage-ui/cypress/support/page-objects/cidsPage.ts
+++ b/packages/storage-ui/cypress/support/page-objects/cidsPage.ts
@@ -16,10 +16,10 @@ export const cidsPage = {
   sizeTableHeader: () => cy.get("[data-cy=table-header-size]"),
   statusTableHeader: () => cy.get("[data-cy=table-header-status]"),
   cidItemRow: () => cy.get("[data-cy=row-cid-item]", { timeout: 20000 }),
-  cidRowKebabButton: () => cy.get("[data-testId=dropdown-title-cid-kebab]"),
+  cidRowKebabButton: () => cy.get("[data-testid=dropdown-title-cid-kebab]"),
 
   // pin cid modal elements
-  pinCidForm: () => cy.get("[data-testId=form-create-bucket]"),
+  pinCidForm: () => cy.get("[data-testid=form-create-bucket]"),
   cidInput: () => cy.get("[data-cy=input-cid]"),
   pinCancelButton: () => cy.get("[data-cy=button-cancel-add-pin]"),
   pinSubmitButton: () => cy.get("[data-cy=button-submit-pin]"),


### PR DESCRIPTION
Something I missed, thanks @tanmoyAtb: React doesn't like having camelCase for data attributes somehow.

So we'll have to live with `data-testid` all lower case, still more consistent than before.

![image](https://user-images.githubusercontent.com/33178835/148264714-03cb8380-0c6b-4677-98ee-30cab5126b80.png)
