### PR TITLE
[Fix] Remove the artificial 65 char limit and fix caption on black theme

### DIFF
--- a/packages/common-components/src/TextInput/TextInput.tsx
+++ b/packages/common-components/src/TextInput/TextInput.tsx
@@ -138,8 +138,8 @@ const useStyles = makeStyles(
           textAlign: "center",
           padding: `${constants.generalUnit}px`,
           transform: "translateX(-50%)",
-          color: palette.common.white.main,
-          backgroundColor: palette.common.black.main,
+          color: palette.additional["gray"][1],
+          backgroundColor: palette.additional["gray"][8],
           ...typography.body2,
           fontWeight: typography.fontWeight.bold,
           zIndex: zIndex?.layer3,
@@ -151,7 +151,7 @@ const useStyles = makeStyles(
             left: "50%",
             borderWidth: constants.generalUnit,
             borderStyle: "solid",
-            borderColor: ` ${palette.common.black.main} transparent transparent transparent`
+            borderColor: ` ${palette.additional["gray"][8]} transparent transparent transparent`
           },
           "&.error": {
             // backgroundColor: palette.error.main,

--- a/packages/files-ui/cypress/tests/file-management-spec.ts
+++ b/packages/files-ui/cypress/tests/file-management-spec.ts
@@ -375,12 +375,11 @@ describe("File management", () => {
       createFolderModal.errorLabel().should("be.visible")
       createFolderModal.body().should("contain.text", "Please enter a name")
 
-      // ensure a folder can't be created if name exceeds 65 characters
+      // ensure a folder can be created even with a large amount of
       createFolderModal.folderNameInput().type("{selectall}{del}")
       createFolderModal.folderNameInput().type("cgsxffymqivoknhwhqvmnchvjngtwsriovhvkgzgmonmimctcrdytujbtkogngvext")
-      createFolderModal.createButton().should("have.attr", "disabled")
-      createFolderModal.errorLabel().should("be.visible")
-      createFolderModal.body().should("contain.text", "Name too long")
+      createFolderModal.createButton().should("not.have.attr", "disabled")
+      createFolderModal.errorLabel().should("not.be.visible")
     })
 
     it("can see storage space summary updated accordingly", () => {

--- a/packages/files-ui/cypress/tests/file-management-spec.ts
+++ b/packages/files-ui/cypress/tests/file-management-spec.ts
@@ -196,7 +196,7 @@ describe("File management", () => {
     })
 
     it("can rename a file with error handling", () => {
-      const newName = "awesome new name"
+      const newName = "awesome new name that is pretty long and it shouldn't matter that much anyway"
 
       cy.web3Login({ clearCSFBucket: true })
 
@@ -374,12 +374,6 @@ describe("File management", () => {
       createFolderModal.createButton().should("have.attr", "disabled")
       createFolderModal.errorLabel().should("be.visible")
       createFolderModal.body().should("contain.text", "Please enter a name")
-
-      // ensure a folder can be created even with a large amount of
-      createFolderModal.folderNameInput().type("{selectall}{del}")
-      createFolderModal.folderNameInput().type("cgsxffymqivoknhwhqvmnchvjngtwsriovhvkgzgmonmimctcrdytujbtkogngvext")
-      createFolderModal.createButton().should("not.have.attr", "disabled")
-      createFolderModal.errorLabel().should("not.be.visible")
     })
 
     it("can see storage space summary updated accordingly", () => {

--- a/packages/files-ui/src/Utils/validationSchema.ts
+++ b/packages/files-ui/src/Utils/validationSchema.ts
@@ -5,7 +5,6 @@ export const nameValidator = object().shape({
   name: string()
     .trim()
     .min(1, t`Please enter a name`)
-    .max(65, t`Name too long`)
     .required("A name is required")
     .test(
       "Invalid name",

--- a/packages/files-ui/src/locales/de/messages.po
+++ b/packages/files-ui/src/locales/de/messages.po
@@ -547,9 +547,6 @@ msgstr "Meine Dateien"
 msgid "Name"
 msgstr "Name"
 
-msgid "Name too long"
-msgstr "Name zu lang"
-
 msgid "New folder"
 msgstr "Neuer Ordner"
 

--- a/packages/files-ui/src/locales/en/messages.po
+++ b/packages/files-ui/src/locales/en/messages.po
@@ -550,9 +550,6 @@ msgstr "My Files"
 msgid "Name"
 msgstr "Name"
 
-msgid "Name too long"
-msgstr "Name too long"
-
 msgid "New folder"
 msgstr "New folder"
 

--- a/packages/files-ui/src/locales/es/messages.po
+++ b/packages/files-ui/src/locales/es/messages.po
@@ -551,9 +551,6 @@ msgstr "Mis Archivos"
 msgid "Name"
 msgstr "Nombre"
 
-msgid "Name too long"
-msgstr ""
-
 msgid "New folder"
 msgstr "Nuevo Folder"
 

--- a/packages/files-ui/src/locales/fr/messages.po
+++ b/packages/files-ui/src/locales/fr/messages.po
@@ -551,9 +551,6 @@ msgstr "Mes Fichiers"
 msgid "Name"
 msgstr "Nom"
 
-msgid "Name too long"
-msgstr "Le nom est trop long"
-
 msgid "New folder"
 msgstr "Nouveau dossier"
 

--- a/packages/files-ui/src/locales/no/messages.po
+++ b/packages/files-ui/src/locales/no/messages.po
@@ -547,9 +547,6 @@ msgstr "Mine filer"
 msgid "Name"
 msgstr "Navn"
 
-msgid "Name too long"
-msgstr "Navnet er for langt"
-
 msgid "New folder"
 msgstr "Ny mappe"
 

--- a/packages/storage-ui/src/Utils/validationSchema.ts
+++ b/packages/storage-ui/src/Utils/validationSchema.ts
@@ -6,7 +6,6 @@ export const nameValidator = object().shape({
   name: string()
     .trim()
     .min(1, t`Please enter a name`)
-    .max(65, t`Name too long`)
     .required("A name is required")
     .test(
       "Invalid name",
@@ -19,7 +18,6 @@ export const bucketNameValidator = (bucketNames: Array<string | undefined>) => o
   name: string()
     .trim()
     .min(1, t`Please enter a name`)
-    .max(65, t`Name too long`)
     .required(t`Bucket name is required`)
     .test(
       "Invalid name",

--- a/packages/storage-ui/src/locales/en/messages.po
+++ b/packages/storage-ui/src/locales/en/messages.po
@@ -226,9 +226,6 @@ msgstr "Move to..."
 msgid "Name"
 msgstr "Name"
 
-msgid "Name too long"
-msgstr "Name too long"
-
 msgid "New Key"
 msgstr "New Key"
 


### PR DESCRIPTION
closes #1874 

after some tests, it seems that the limit in the name isn't enforced by the api side, for folders or shared folders (buckets) so I removed them all. While testing in dark mode I realize than we had a certainly long standing issue where the error message weren't readable, black on black. That's also fixed now

Before:
![image](https://user-images.githubusercontent.com/33178835/150805011-87c21e19-5e6d-42ae-b0b5-b151979fed21.png)

After
![image](https://user-images.githubusercontent.com/33178835/150803732-4a061d3c-31ef-4744-a06e-2ba4abad876b.png)


---
Submission checklist: 

<!-- Remove anything below that is not applicable -->   

#### Layout
- [x] Change looks good in the desktop web ui
- [x] Change looks good in the mobile web ui

#### Theme
- [x] Components / elements inspected in light mode 
- [x] Components / elements inspected in dark mode 
