### PR TITLE
Streamline loader when paying with crypto

### DIFF
--- a/packages/files-ui/src/Components/Modules/Settings/SubscriptionTab/Common/CryptoPayment.tsx
+++ b/packages/files-ui/src/Components/Modules/Settings/SubscriptionTab/Common/CryptoPayment.tsx
@@ -239,7 +239,7 @@ const CryptoPayment = ({ planPrice }: ICryptoPayment) => {
   const debouncedSwitchCopiedAmount = debounce(() => setCopiedAmount(false), 3000)
   const pendingCryptoInvoice = useMemo(() =>
     invoices?.find((i) => i.payment_method === "crypto" && i.status === "open")
-  , [invoices])
+    , [invoices])
   const currencies = useMemo(() => cryptoPayment?.payment_methods.map(c => c.currency), [cryptoPayment])
   const [selectedCurrency, setSelectedCurrency] = useState<string | undefined>(undefined)
 
@@ -284,7 +284,7 @@ const CryptoPayment = ({ planPrice }: ICryptoPayment) => {
 
   const selectedPaymentMethod = useMemo(() =>
     cryptoPayment && selectedCurrency && cryptoPayment.payment_methods.find(p => p.currency === selectedCurrency)
-  , [cryptoPayment, selectedCurrency])
+    , [cryptoPayment, selectedCurrency])
 
   const onCopyDestinationAddress = useCallback(() => {
     if (!selectedPaymentMethod) return
@@ -367,7 +367,7 @@ const CryptoPayment = ({ planPrice }: ICryptoPayment) => {
           />
         </div>}
       </div>
-      {(cryptoChargeLoading || (pendingCryptoInvoice && !cryptoPayment)) && <div className={classes.loadingContainer}>
+      {(cryptoChargeLoading || !cryptoPayment) && <div className={classes.loadingContainer}>
         <Loading type='initial' />
       </div>}
       {error &&

--- a/packages/files-ui/src/Components/Modules/Settings/SubscriptionTab/Common/CryptoPayment.tsx
+++ b/packages/files-ui/src/Components/Modules/Settings/SubscriptionTab/Common/CryptoPayment.tsx
@@ -239,7 +239,7 @@ const CryptoPayment = ({ planPrice }: ICryptoPayment) => {
   const debouncedSwitchCopiedAmount = debounce(() => setCopiedAmount(false), 3000)
   const pendingCryptoInvoice = useMemo(() =>
     invoices?.find((i) => i.payment_method === "crypto" && i.status === "open")
-    , [invoices])
+  , [invoices])
   const currencies = useMemo(() => cryptoPayment?.payment_methods.map(c => c.currency), [cryptoPayment])
   const [selectedCurrency, setSelectedCurrency] = useState<string | undefined>(undefined)
 
@@ -284,7 +284,7 @@ const CryptoPayment = ({ planPrice }: ICryptoPayment) => {
 
   const selectedPaymentMethod = useMemo(() =>
     cryptoPayment && selectedCurrency && cryptoPayment.payment_methods.find(p => p.currency === selectedCurrency)
-    , [cryptoPayment, selectedCurrency])
+  , [cryptoPayment, selectedCurrency])
 
   const onCopyDestinationAddress = useCallback(() => {
     if (!selectedPaymentMethod) return


### PR DESCRIPTION
When loading a crypto payment, there's a loader, then nothing for a second, then a loader again, then the info appear. 
This fixes it.

LMK if you don't know what I'm talking about, I can do a video.

Submission checklist: 

<!-- Remove anything below that is not applicable -->   

#### Layout
- [x] Change looks good in the desktop web ui
- [x] Change looks good in the mobile web ui

#### Theme
- [x] Components / elements inspected in light mode 
- [x] Components / elements inspected in dark mode 
