### PR TITLE
Fix time left in crypto payment

### DIFF
--- a/packages/files-ui/src/Components/Modules/Settings/SubscriptionTab/Common/CryptoPayment.tsx
+++ b/packages/files-ui/src/Components/Modules/Settings/SubscriptionTab/Common/CryptoPayment.tsx
@@ -231,7 +231,7 @@ const CryptoPayment = ({ planPrice }: ICryptoPayment) => {
   const [error, setError] = useState<string | undefined>(undefined)
   const [cryptoChargeLoading, setCryptoChargeLoading] = useState(false)
   const [transferActive, setTransferActive] = useState(false)
-  const [timeRemaining, setTimeRemaining] = useState<string | undefined>()
+  const [timeRemaining, setTimeRemaining] = useState<duration.Duration | undefined>()
   const pageLoadTimestamp = useRef(dayjs().unix())
   const [copiedDestinationAddress, setCopiedDestinationAddress] = useState(false)
   const [copiedAmount, setCopiedAmount] = useState(false)
@@ -273,7 +273,7 @@ const CryptoPayment = ({ planPrice }: ICryptoPayment) => {
   useEffect(() => {
     const timer = setInterval(() => {
       if (cryptoPayment) {
-        setTimeRemaining(dayjs.duration(cryptoPayment.expires_at - dayjs().unix(), "s").format("mm:ss"))
+        setTimeRemaining(dayjs.duration(cryptoPayment.expires_at - dayjs().unix(), "s"))
       }
     }, 1000)
 
@@ -360,9 +360,9 @@ const CryptoPayment = ({ planPrice }: ICryptoPayment) => {
         </Typography>
         {cryptoPayment && <div className={classes.pushRightBox}>
           <CircularProgressBar
-            progress={(cryptoPayment.expires_at - dayjs().unix()) / (cryptoPayment.expires_at - pageLoadTimestamp.current) * 100}
-            width={23}
-            label={timeRemaining}
+            progress={(timeRemaining?.as("s") || 0) / 3600 * 100}
+            width={100}
+            label={timeRemaining?.format("mm:ss") || ""}
             variant="secondary"
           />
         </div>}

--- a/packages/files-ui/src/Components/Modules/Settings/SubscriptionTab/Common/CryptoPayment.tsx
+++ b/packages/files-ui/src/Components/Modules/Settings/SubscriptionTab/Common/CryptoPayment.tsx
@@ -361,7 +361,7 @@ const CryptoPayment = ({ planPrice }: ICryptoPayment) => {
         {cryptoPayment && <div className={classes.pushRightBox}>
           <CircularProgressBar
             progress={(timeRemaining?.as("s") || 0) / 3600 * 100}
-            width={100}
+            width={23}
             label={timeRemaining?.format("mm:ss") || ""}
             variant="secondary"
           />


### PR DESCRIPTION
closes a bug that I noticed recently. If you start a crypto payment, then go back to it 20min later (using the "see payment info" button for instance), the time remaining will correctly show that you have 40min left, but the loading progression will actually be 100%. I fixed this here.

---
Submission checklist: 

<!-- Remove anything below that is not applicable -->   

#### Layout
- [x] Change looks good in the desktop web ui
- [x] Change looks good in the mobile web ui

#### Theme
- [x] Components / elements inspected in light mode 
- [x] Components / elements inspected in dark mode 
