### PR TITLE
Style the error boundaries component

### DIFF
--- a/packages/files-ui/src/App.tsx
+++ b/packages/files-ui/src/App.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback } from "react"
-import { init as initSentry, ErrorBoundary, showReportDialog } from "@sentry/react"
+import React from "react"
+import { init as initSentry, ErrorBoundary } from "@sentry/react"
 import { Web3Provider } from "@chainsafe/web3-context"
 import { ThemeSwitcher } from "@chainsafe/common-theme"
 import "@chainsafe/common-theme/dist/font-faces.css"
-import { Button, CssBaseline, Modal, Router, ToastProvider, Typography } from "@chainsafe/common-components"
+import { CssBaseline, Router, ToastProvider } from "@chainsafe/common-components"
 import { FilesProvider } from "./Contexts/FilesContext"
 import FilesRoutes from "./Components/FilesRoutes"
 import AppWrapper from "./Components/Layouts/AppWrapper"
@@ -18,6 +18,7 @@ import { BillingProvider } from "./Contexts/BillingContext"
 import { PosthogProvider } from "./Contexts/PosthogContext"
 import { NotificationsProvider } from "./Contexts/NotificationsContext"
 import { StylesProvider, createGenerateClassName } from "@material-ui/styles"
+import ErrorModal from "./Components/Modules/ErrorModal"
 
 // making material and jss use one className generator
 const generateClassName = createGenerateClassName({
@@ -77,29 +78,6 @@ const App = () => {
   // This will default to testnet unless mainnet is specifically set in the ENV
   const directAuthNetwork = (process.env.REACT_APP_DIRECT_AUTH_NETWORK === "mainnet") ? "mainnet" : "testnet"
 
-  const fallBack = useCallback(({ error, componentStack, eventId, resetError }) => (
-    <Modal
-      active
-      closePosition="none"
-      onClose={resetError}
-    >
-      <Typography>
-        An error occurred and has been logged. If you would like to
-        provide additional info to help us debug and resolve the issue,
-        click the `&quot;`Provide Additional Details`&quot;` button
-      </Typography>
-      <Typography>{error?.message.toString()}</Typography>
-      <Typography>{componentStack}</Typography>
-      <Typography>{eventId}</Typography>
-      <Button
-        onClick={() => showReportDialog({ eventId: eventId || "" })}
-      >
-        Provide Additional Details
-      </Button>
-      <Button onClick={resetError}>Reset error</Button>
-    </Modal>
-  ), [])
-
   return (
     <StylesProvider generateClassName={generateClassName}>
       <ThemeSwitcher
@@ -107,7 +85,7 @@ const App = () => {
         themes={{ light: lightTheme, dark: darkTheme }}
       >
         <ErrorBoundary
-          fallback={fallBack}
+          fallback={ErrorModal}
           onReset={() => window.location.reload()}
         >
           <CssBaseline />

--- a/packages/files-ui/src/Components/Modules/ErrorModal.tsx
+++ b/packages/files-ui/src/Components/Modules/ErrorModal.tsx
@@ -1,0 +1,102 @@
+/* eslint-disable max-len */
+import React from "react"
+import { Button, Modal, Typography } from "@chainsafe/common-components"
+import { ROUTE_LINKS } from "../FilesRoutes"
+
+interface Props {
+  error: Error
+  componentStack: string | null
+  eventId: string | null
+  resetError: () => void
+}
+
+const ErrorModal = ({ error, componentStack, resetError }: Props) => {
+
+  const generalStyle = { margin: "1rem" }
+
+  return <Modal
+    active
+    closePosition="none"
+    onClose={resetError}
+  >
+    <Typography
+      variant="h2"
+      style={{
+        marginTop: "3rem",
+        display: "inline-block",
+        ...generalStyle
+      }}
+    >
+        An unexpected error occured
+    </Typography>
+    <Typography
+      component="p"
+      style={{ ...generalStyle }}
+    >
+        If you would like to provide additional info to help us debug and resolve the issue, reach out on <a
+        target="_blank"
+        rel="noopener noreferrer"
+        href={ROUTE_LINKS.DiscordInvite}
+      >
+        Discord
+      </a>
+    </Typography>
+    <br/>
+    <Typography
+      variant="h4"
+      style={{
+        ...generalStyle,
+        display: "inline-block"
+      }}
+    >
+        Error:
+    </Typography>
+    <Typography
+      style={{
+        ...generalStyle,
+        backgroundColor: "ghostwhite",
+        padding: "1rem",
+        marginTop: 0
+      }}
+      component="p"
+    >
+      <pre>{error?.message.toString()}</pre>
+    </Typography>
+    <Typography
+      variant="h4"
+      style={{
+        ...generalStyle,
+        display: "inline-block"
+      }}
+    >
+        Stack:
+    </Typography>
+    <Typography
+      component="p"
+      style={{
+        ...generalStyle,
+        height: "5rem",
+        overflow: "auto",
+        padding: "1rem",
+        border: "2px solid ghostwhite",
+        marginTop: 0
+      }}
+    >
+      {componentStack}
+    </Typography>
+    <div
+      style={{
+        ...generalStyle,
+        display: "flex",
+        justifyContent: "center"
+
+      }}
+    >
+      <Button onClick={resetError}>
+        Close
+      </Button>
+    </div>
+  </Modal>
+}
+
+export default ErrorModal

--- a/packages/files-ui/src/Components/Modules/ErrorModal.tsx
+++ b/packages/files-ui/src/Components/Modules/ErrorModal.tsx
@@ -12,7 +12,11 @@ interface Props {
 
 const ErrorModal = ({ error, componentStack, resetError }: Props) => {
 
-  const generalStyle = { margin: "1rem" }
+  const generalStyle = {
+    margin: "1rem",
+    backgrounColor: "var(--gray1)",
+    color: "var(--gray9)"
+  }
 
   return <Modal
     active
@@ -56,7 +60,8 @@ const ErrorModal = ({ error, componentStack, resetError }: Props) => {
         ...generalStyle,
         backgroundColor: "ghostwhite",
         padding: "1rem",
-        marginTop: 0
+        marginTop: 0,
+        color: "black"
       }}
       component="p"
     >

--- a/packages/files-ui/src/Components/Modules/SearchModule.tsx
+++ b/packages/files-ui/src/Components/Modules/SearchModule.tsx
@@ -146,16 +146,9 @@ interface ISearchModule {
   setSearchActive: (searchActive: boolean) => void
 }
 
-const SearchModule: React.FC<ISearchModule> = ({
-  className,
-  searchActive,
-  setSearchActive
-}: ISearchModule) => {
+const SearchModule = ({ className, searchActive, setSearchActive }: ISearchModule) => {
   const { themeKey, desktop } = useThemeSwitcher()
-  const classes = useStyles({
-    themeKey
-  })
-
+  const classes = useStyles({ themeKey })
   const [searchQuery, setSearchQuery] = useState<string>("")
   const [searchResults, setSearchResults] = useState<{results: SearchEntry[]; query: string} | undefined>(undefined)
   const ref = useRef(null)


### PR DESCRIPTION
closes #41 ooooh that feels good!

I wasn't able to use `createStyle`, the app kept crashing, saying I wasn't able to use `useTheme`. so I did this all manually :man_shrugging:.

Edit: error boundaries are a weird kind of component based on old fashion classes where you can't use hooks basically https://blog.lookitskris.com/error-boundaries-hooks/

![image](https://user-images.githubusercontent.com/33178835/152188745-2c871c8b-30b5-4804-a3f3-9874510470ef.png)
![image](https://user-images.githubusercontent.com/33178835/152190619-e49c5c30-bcb6-432d-bd72-bd1d149f30eb.png)

---
Submission checklist: 

<!-- Remove anything below that is not applicable -->   

#### Layout
- [x] Change looks good in the desktop web ui
- [x] Change looks good in the mobile web ui

#### Theme
- [x] Components / elements inspected in light mode 
- [x] Components / elements inspected in dark mode 
