### PR TITLE
Fix User Profile Button text overflow

### DIFF
--- a/packages/files-ui/src/Components/Layouts/AppNav.tsx
+++ b/packages/files-ui/src/Components/Layouts/AppNav.tsx
@@ -204,6 +204,7 @@ const useStyles = makeStyles(
         marginBottom: constants.generalUnit
       },
       profileButton: {
+        maxWidth: 144,
         borderRadius: 4,
         display: "flex",
         alignItems: "center",
@@ -229,6 +230,11 @@ const useStyles = makeStyles(
       },
       menuTitle: {
         padding: `${constants.generalUnit * 1.5}px 0`
+      },
+      profileLabel: {
+        overflow: "hidden",
+        whiteSpace: "nowrap",
+        textOverflow: "ellipsis"
       }
     })
   }
@@ -318,6 +324,7 @@ const AppNav = ({ navOpen, setNavOpen }: IAppNav) => {
                     <Typography
                       variant="body1"
                       component="p"
+                      className={classes.profileLabel}
                     >
                       {profileTitle}
                     </Typography>


### PR DESCRIPTION
closes #1920

![image](https://user-images.githubusercontent.com/12774278/153032196-d2dfb19b-4ab3-4775-a128-a33edd8732ec.png)

---
Submission checklist: 

#### Layout
- [x] Change looks good in the desktop web ui
- [x] Change looks good in the mobile web ui

#### Theme
- [x] Components / elements inspected in light mode 
- [x] Components / elements inspected in dark mode 
