### PR TITLE
Run tests when yarn.lock is changed

### DIFF
--- a/.github/workflows/test-files.yml
+++ b/.github/workflows/test-files.yml
@@ -8,6 +8,7 @@ on:
     - package.json
     - .eslintrc.json
     - tsconfig.json
+    - yarn.lock
 jobs:
   cypress-run:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-storage.yml
+++ b/.github/workflows/test-storage.yml
@@ -8,6 +8,7 @@ on:
     - package.json
     - .eslintrc.json
     - tsconfig.json
+    - yarn.lock
 jobs:
   cypress-run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Make sure tests are run when `yarn.lock` is changed, such as when there's a Dependabot security PR

---

No layout change