### PR TITLE
Show 'me' instead of the user icon

### DIFF
--- a/packages/files-ui/src/Components/Modules/FileBrowsers/views/FileSystemItem/SharedFolderRow.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/views/FileSystemItem/SharedFolderRow.tsx
@@ -163,7 +163,8 @@ const SharedFolderRow = ({ bucket, handleRename, openSharedFolder, handleDeleteS
 
   useEffect(() => {
     if (isOwner) {
-      setOwnerName("me")
+      // we will show "me" instead of the icon
+      // if we are the owner
       return
     }
 
@@ -317,10 +318,14 @@ const SharedFolderRow = ({ bucket, handleRename, openSharedFolder, handleDeleteS
         </TableCell>
         {desktop &&
         <TableCell align="left">
-          <UserBubble
-            tooltip={ownerName}
-            hashIconValue={bucket.owners[0].uuid}
-          />
+          {
+            isOwner
+              ? t`me`
+              : <UserBubble
+                tooltip={ownerName}
+                hashIconValue={bucket.owners[0].uuid}
+              />
+          }
         </TableCell>
         }
         <TableCell

--- a/packages/files-ui/src/locales/de/messages.po
+++ b/packages/files-ui/src/locales/de/messages.po
@@ -1159,6 +1159,9 @@ msgstr ""
 msgid "invoices here"
 msgstr ""
 
+msgid "me"
+msgstr ""
+
 msgid "on"
 msgstr "am"
 

--- a/packages/files-ui/src/locales/en/messages.po
+++ b/packages/files-ui/src/locales/en/messages.po
@@ -1162,6 +1162,9 @@ msgstr "expires"
 msgid "invoices here"
 msgstr "invoices here"
 
+msgid "me"
+msgstr "me"
+
 msgid "on"
 msgstr "on"
 

--- a/packages/files-ui/src/locales/es/messages.po
+++ b/packages/files-ui/src/locales/es/messages.po
@@ -1163,6 +1163,9 @@ msgstr ""
 msgid "invoices here"
 msgstr ""
 
+msgid "me"
+msgstr ""
+
 msgid "on"
 msgstr "en"
 

--- a/packages/files-ui/src/locales/fr/messages.po
+++ b/packages/files-ui/src/locales/fr/messages.po
@@ -1163,6 +1163,9 @@ msgstr "expire"
 msgid "invoices here"
 msgstr "factures ici"
 
+msgid "me"
+msgstr ""
+
 msgid "on"
 msgstr "le"
 

--- a/packages/files-ui/src/locales/no/messages.po
+++ b/packages/files-ui/src/locales/no/messages.po
@@ -1159,6 +1159,9 @@ msgstr ""
 msgid "invoices here"
 msgstr ""
 
+msgid "me"
+msgstr ""
+
 msgid "on"
 msgstr ""
 


### PR DESCRIPTION
In a change I made earlier this week, I made this mistake where you'd show the user identicon, even if it's us. This gets back to what we have previously, I think it helps knowing where we are the owner right away.