### PR TITLE
Resolve yarn.lock issue in gh actions test jobs

### DIFF
--- a/.github/workflows/test-files-on-demand.yml
+++ b/.github/workflows/test-files-on-demand.yml
@@ -15,7 +15,7 @@ jobs:
             **/node_modules
             ~/.cache/Cypress
             **/build
-          key: ${{ runner.os }}-node_modules-files-build-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node_modules-files-build-${{ hashFiles('./yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-node_modules-build-
 

--- a/.github/workflows/test-files.yml
+++ b/.github/workflows/test-files.yml
@@ -24,7 +24,7 @@ jobs:
             **/node_modules
             ~/.cache/Cypress
             **/build
-          key: ${{ runner.os }}-node_modules-files-build-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node_modules-files-build-${{ hashFiles('./yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-node_modules-build-
 

--- a/.github/workflows/test-files.yml
+++ b/.github/workflows/test-files.yml
@@ -24,7 +24,7 @@ jobs:
             **/node_modules
             ~/.cache/Cypress
             **/build
-          key: ${{ runner.os }}-node_modules-files-build-${{ hashFiles('./yarn.lock') }}
+          key: ${{ runner.os }}-node_modules-files-build-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-node_modules-build-
 

--- a/.github/workflows/test-storage.yml
+++ b/.github/workflows/test-storage.yml
@@ -24,7 +24,7 @@ jobs:
             **/node_modules
             ~/.cache/Cypress
             **/build
-          key: ${{ runner.os }}-node_modules-build-storage-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node_modules-build-storage-${{ hashFiles('./yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-node_modules-build-
 

--- a/packages/files-ui/cypress/tests/settings-spec.ts
+++ b/packages/files-ui/cypress/tests/settings-spec.ts
@@ -10,7 +10,7 @@ describe("Settings", () => {
       navigationMenu.settingsNavButton().click()
     })
 
-    it("can navigate to settings profile page", () => {
+    it.only("can navigate to settings profile page", () => {
       settingsPage.profileTabHeader().should("be.visible")
       cy.url().should("include", "/settings")
       settingsPage.profileTabButton().click()

--- a/packages/files-ui/cypress/tests/settings-spec.ts
+++ b/packages/files-ui/cypress/tests/settings-spec.ts
@@ -10,7 +10,7 @@ describe("Settings", () => {
       navigationMenu.settingsNavButton().click()
     })
 
-    it.only("can navigate to settings profile page", () => {
+    it("can navigate to settings profile page", () => {
       settingsPage.profileTabHeader().should("be.visible")
       cy.url().should("include", "/settings")
       settingsPage.profileTabButton().click()


### PR DESCRIPTION
~~Please ignore, just using this branch for troubleshooting~~

This fixes the issue we are seeing in CI on failed tests 

``Error: The template is not valid. .github/workflows/test-files.yml (Line: 27, Col: 16): hashFiles('**/yarn.lock') failed. Fail to hash files under directory '/home/runner/work/ui-monorepo/ui-monorepo``

I suspect the wildcarding of the yarn.lock file was not a tight enough match and it was picking up a yarn.lock in one of the dependencies instead. Now we specifically target the yarn.lock in the root dir. 
