### PR TITLE
Add ui tests for copying / moving to share folders

### DIFF
--- a/packages/files-ui/cypress/support/page-objects/homePage.ts
+++ b/packages/files-ui/cypress/support/page-objects/homePage.ts
@@ -25,6 +25,7 @@ export const homePage = {
   renameMenuOption: () => cy.get("[data-cy=menu-rename]"),
   moveMenuOption: () => cy.get("[data-cy=menu-move]"),
   deleteMenuOption: () => cy.get("[data-cy=menu-delete]"),
+  shareMenuOption: () => cy.get("[data-cy=menu-share]"),
 
   // helpers and convenience functions
   uploadFile(filePath: string) {

--- a/packages/files-ui/cypress/support/page-objects/modals/editSharedFolderModal.ts
+++ b/packages/files-ui/cypress/support/page-objects/modals/editSharedFolderModal.ts
@@ -1,6 +1,6 @@
 export const editSharedFolderModal = {
   body: () => cy.get("[data-testid=modal-container-edit-shared-folder]", { timeout: 10000 }),
-  cancelButton: () => cy.get("[data-cy=button-cancel-create-shared-folder]"),
+  closeButton: () => cy.get("[data-cy=button-close-manage-shared-folder]"),
   createButton: () => cy.get("[data-cy=button-create-shared-folder]", { timeout: 10000 }),
   editPermissionInput: () => cy.get("[data-cy=input-edit-permission]"),
   folderNameInput: () => cy.get("[data-cy=input-shared-folder-name]"),

--- a/packages/files-ui/cypress/support/page-objects/modals/shareFileModal.ts
+++ b/packages/files-ui/cypress/support/page-objects/modals/shareFileModal.ts
@@ -1,0 +1,10 @@
+export const shareFileModal = {
+  body: () => cy.get("[data-testid=modal-container-share-file]", { timeout: 10000 }),
+  shareNameInput: () => cy.get("[data-cy=input-new-share-name]"),
+  selectFolderInput: () => cy.get("[data-cy=input-select-existing-folder]"),
+  existingFolderInputOption: () => cy.get("[data-cy=input-select-existing-folder]"),
+  keepOriginalFilesCheckbox: () => cy.get("[data-testid=checkbox-keep-original-files]"),
+  cancelButton: () => cy.get("[data-testid=button-cancel-share-file]"),
+  copyOverButton: () => cy.get("[data-testid=button-copy-over]"),
+  moveOverButton: () => cy.get("[data-testid=button-move-over]")
+}

--- a/packages/files-ui/cypress/support/page-objects/modals/shareFileModal.ts
+++ b/packages/files-ui/cypress/support/page-objects/modals/shareFileModal.ts
@@ -2,7 +2,7 @@ export const shareFileModal = {
   body: () => cy.get("[data-testid=modal-container-share-file]", { timeout: 10000 }),
   shareNameInput: () => cy.get("[data-cy=input-new-share-name]"),
   selectFolderInput: () => cy.get("[data-cy=input-select-existing-folder]"),
-  existingFolderInputOption: () => cy.get("[data-cy=input-select-existing-folder]"),
+  existingFolderInputOption: () => cy.get("[data-cy=input-select-existing-folder-option]"),
   keepOriginalFilesCheckbox: () => cy.get("[data-testid=checkbox-keep-original-files]"),
   cancelButton: () => cy.get("[data-testid=button-cancel-share-file]"),
   copyOverButton: () => cy.get("[data-testid=button-copy-over]"),

--- a/packages/files-ui/cypress/support/page-objects/sharedPage.ts
+++ b/packages/files-ui/cypress/support/page-objects/sharedPage.ts
@@ -30,7 +30,7 @@ export const sharedPage = {
     createSharedFolderModal.body().should("be.visible")
     createSharedFolderModal.folderNameInput().type(sharedFolderName)
     createSharedFolderModal.createButton().safeClick()
-    editSharedFolderModal.cancelButton().safeClick()
+    editSharedFolderModal.closeButton().safeClick()
     editSharedFolderModal.body().should("not.exist")
     sharedPage.sharedFolderItemRow().should("have.length", 1)
   }

--- a/packages/files-ui/cypress/support/page-objects/sharedPage.ts
+++ b/packages/files-ui/cypress/support/page-objects/sharedPage.ts
@@ -11,7 +11,7 @@ export const sharedPage = {
   createSharedFolderButton: () => cy.get("[data-cy=button-create-a-shared-folder]"),
   sharedFolderItemRow: () => cy.get("[data-cy=row-shared-folder-item]", { timeout: 20000 }),
   sharedFolderIcon: () => cy.get("[data-cy=cell-shared-folder-icon]"),
-  sharedFolderItemName: () => cy.get("[data-cy=cell-shared-folder-item-name]"),
+  sharedFolderItemName: () => cy.get("[data-cy=cell-shared-folder-item-name]", { timeout: 10000 }),
   shareOwnerCell: () => cy.get("[data-cy=cell-share-owner]"),
   sharedWithCell: () => cy.get("[data-cy=cell-shared-with]"),
   sharedFolderSizeCell: () => cy.get("[data-cy=cell-shared-folder-size]"),

--- a/packages/files-ui/cypress/support/page-objects/toasts/shareSuccessToast.ts
+++ b/packages/files-ui/cypress/support/page-objects/toasts/shareSuccessToast.ts
@@ -1,0 +1,4 @@
+export const shareSuccessToast = {
+  body: () => cy.get("[data-testid=toast-share-success]", { timeout: 10000 }),
+  closeButton: () => cy.get("[data-testid=button-close-toast-share-success]")
+}

--- a/packages/files-ui/cypress/support/page-objects/toasts/sharingProgressToast.ts
+++ b/packages/files-ui/cypress/support/page-objects/toasts/sharingProgressToast.ts
@@ -1,0 +1,4 @@
+export const sharingProgressToast = {
+  body: () => cy.get("[data-testid=toast-sharing-progress]", { timeout: 10000 }),
+  closeButton: () => cy.get("[data-testid=button-close-toast-sharing-progress]")
+}

--- a/packages/files-ui/cypress/support/utils/apiTestHelper.ts
+++ b/packages/files-ui/cypress/support/utils/apiTestHelper.ts
@@ -141,7 +141,5 @@ export const apiTestHelper = {
         homePage.fileItemName().contains(firstFolderName)
       })
     })
-
-
   }
 }

--- a/packages/files-ui/cypress/tests/file-management-spec.ts
+++ b/packages/files-ui/cypress/tests/file-management-spec.ts
@@ -58,9 +58,9 @@ describe("File management", () => {
       // create a folder 
       apiTestHelper.createFolder(folderPath)
 
-      cy.get("@fileName").then(($fileName) => {
+      cy.get<string>("@fileName").then((fileName) => {
         // select the file and move it to the folder
-        homePage.fileItemName().contains(`${$fileName}`)
+        homePage.fileItemName().contains(fileName)
           .should("be.visible")
           .click()
         homePage.moveSelectedButton().click()
@@ -79,10 +79,10 @@ describe("File management", () => {
           .should("be.visible")
           .dblclick()
         homePage.fileItemRow().should("have.length", 1)
-        homePage.fileItemName().should("contain.text", $fileName)
+        homePage.fileItemName().should("contain.text", fileName)
 
         // move the file back to the home root
-        homePage.fileItemName().contains(`${$fileName}`)
+        homePage.fileItemName().contains(fileName)
           .should("be.visible")
           .click()
         homePage.moveSelectedButton().click()
@@ -98,10 +98,10 @@ describe("File management", () => {
           .should("be.visible")
           .should("have.length", 2)
         homePage.fileItemName().should("contain.text", folderName)
-        homePage.fileItemName().should("contain.text", $fileName)
+        homePage.fileItemName().should("contain.text", fileName)
 
         // ensure file already in the root cannot be moved to Home
-        homePage.fileItemName().contains(`${$fileName}`)
+        homePage.fileItemName().contains(fileName)
           .should("be.visible")
           .click()
         homePage.moveSelectedButton().click()
@@ -259,8 +259,8 @@ describe("File management", () => {
       binPage.fileItemName().invoke("text").as("binFile")
 
       // ensure file in bin matches the name of the deleted file
-      cy.get("@originalFile").then(($originalFile) => {
-        cy.get("@binFile").should("equals", $originalFile)
+      cy.get<string>("@originalFile").then((originalFile) => {
+        cy.get("@binFile").should("equals", originalFile)
       })
 
       // recover the file via the menu option
@@ -281,8 +281,8 @@ describe("File management", () => {
       binPage.fileItemRow().should("have.length", 1)
 
       // ensure file moved from the bin matches the name of the recovered file
-      cy.get("@recoveredFile").then(($recoveredFile) => {
-        cy.get("@binFile").should("equals", $recoveredFile)
+      cy.get<string>("@recoveredFile").then((recoveredFile) => {
+        cy.get("@binFile").should("equals", recoveredFile)
       })
 
       // permanently delete the file
@@ -437,12 +437,12 @@ describe("File management", () => {
       // return home and ensure both of the files were recovered
       navigationMenu.homeNavButton().click()
 
-      cy.get("@fileNameA").then(($fileNameA) => {
-        homePage.fileItemName().should("contain.text", $fileNameA)
+      cy.get<string>("@fileNameA").then((fileNameA) => {
+        homePage.fileItemName().should("contain.text", fileNameA)
       })
 
-      cy.get("@fileNameB").then(($fileNameB) => {
-        homePage.fileItemName().should("contain.text", $fileNameB)
+      cy.get<string>("@fileNameB").then((fileNameB) => {
+        homePage.fileItemName().should("contain.text", fileNameB)
       })
     })
   })

--- a/packages/files-ui/cypress/tests/file-management-spec.ts
+++ b/packages/files-ui/cypress/tests/file-management-spec.ts
@@ -50,7 +50,7 @@ describe("File management", () => {
     it("can move a file in and out of a folder", () => {
       cy.web3Login({ clearCSFBucket: true })
 
-      // upload a file and save it's name as a cypress alias
+      // upload a file and save its name as a cypress alias
       homePage.uploadFile("../fixtures/uploadedFiles/text-file.txt")
       homePage.fileItemRow().should("have.length", 1)
       homePage.fileItemName().invoke("text").as("fileName")

--- a/packages/files-ui/cypress/tests/file-preview-spec.ts
+++ b/packages/files-ui/cypress/tests/file-preview-spec.ts
@@ -23,24 +23,24 @@ describe("File Preview", () => {
       previewModal.body().should("exist")
 
       // ensure the correct file is being previewed
-      cy.get("@fileNameA").then(($fileNameA) => {
-        previewModal.fileNameLabel().should("contain.text", $fileNameA)
+      cy.get<string>("@fileNameA").then((fileNameA) => {
+        previewModal.fileNameLabel().should("contain.text", fileNameA)
         previewModal.contentContainer().should("be.visible")
         previewModal.unsupportedFileLabel().should("not.exist")
       })
 
       // browse to the next file 
       previewModal.nextFileButton().click()
-      cy.get("@fileNameB").then(($fileNameB) => {
-        previewModal.fileNameLabel().should("contain.text", $fileNameB)
+      cy.get<string>("@fileNameB").then((fileNameB) => {
+        previewModal.fileNameLabel().should("contain.text", fileNameB)
         previewModal.contentContainer().should("be.visible")
         previewModal.unsupportedFileLabel().should("not.exist")
       })
 
       // return to the previous file
       previewModal.previousFileButton().click()
-      cy.get("@fileNameA").then(($fileNameA) => {
-        previewModal.fileNameLabel().should("contain.text", $fileNameA)
+      cy.get<string>("@fileNameA").then((fileNameA) => {
+        previewModal.fileNameLabel().should("contain.text", fileNameA)
         previewModal.contentContainer().should("be.visible")
         previewModal.unsupportedFileLabel().should("not.exist")
       })
@@ -71,8 +71,8 @@ describe("File Preview", () => {
       previewModal.body().should("exist")
 
       // ensure the correct file is being previewed
-      cy.get("@fileNameA").then(($fileNameA) => {
-        previewModal.fileNameLabel().should("contain.text", $fileNameA)
+      cy.get<string>("@fileNameA").then((fileNameA) => {
+        previewModal.fileNameLabel().should("contain.text", fileNameA)
         previewModal.contentContainer()
           .should("be.visible")
           .should("not.have.text", "Loading preview")
@@ -81,8 +81,8 @@ describe("File Preview", () => {
 
       // browse to the 2nd file via the right arrow key
       cy.get("body").type("{rightarrow}")
-      cy.get("@fileNameB").then(($fileNameB) => {
-        previewModal.fileNameLabel().should("contain.text", $fileNameB)
+      cy.get<string>("@fileNameB").then((fileNameB) => {
+        previewModal.fileNameLabel().should("contain.text", fileNameB)
         previewModal.contentContainer()
           .should("be.visible")
           .should("not.have.text", "Loading preview")
@@ -91,8 +91,8 @@ describe("File Preview", () => {
 
       // browse to the 3rd file via the right arrow key
       cy.get("body").type("{rightarrow}")
-      cy.get("@fileNameC").then(($fileNameC) => {
-        previewModal.fileNameLabel().should("contain.text", $fileNameC)
+      cy.get<string>("@fileNameC").then((fileNameC) => {
+        previewModal.fileNameLabel().should("contain.text", fileNameC)
         previewModal.contentContainer()
           .should("be.visible")
           .should("not.have.text", "Loading preview")
@@ -101,8 +101,8 @@ describe("File Preview", () => {
 
       // return to the 2nd file via the left arrow key
       cy.get("body").type("{leftarrow}")
-      cy.get("@fileNameB").then(($fileNameB) => {
-        previewModal.fileNameLabel().should("contain.text", $fileNameB)
+      cy.get<string>("@fileNameB").then((fileNameB) => {
+        previewModal.fileNameLabel().should("contain.text", fileNameB)
         previewModal.contentContainer()
           .should("be.visible")
           .should("not.have.text", "Loading preview")
@@ -111,8 +111,8 @@ describe("File Preview", () => {
 
       // return to the 1st file via the left arrow key
       cy.get("body").type("{leftarrow}")
-      cy.get("@fileNameA").then(($fileNameA) => {
-        previewModal.fileNameLabel().should("contain.text", $fileNameA)
+      cy.get<string>("@fileNameA").then((fileNameA) => {
+        previewModal.fileNameLabel().should("contain.text", fileNameA)
         previewModal.contentContainer()
           .should("be.visible")
           .should("not.have.text", "Loading preview")

--- a/packages/files-ui/cypress/tests/file-sharing-spec.ts
+++ b/packages/files-ui/cypress/tests/file-sharing-spec.ts
@@ -174,11 +174,11 @@ describe("File Sharing", () => {
     it("can copy a file to a new shared folder and preserve original", () => {
       cy.web3Login({ deleteShareBucket: true, clearCSFBucket: true })
 
-      // upload a file and store it's name as cypress alias
+      // upload a file and store its name as cypress alias
       homePage.uploadFile("../fixtures/uploadedFiles/logo.png")
       homePage.fileItemName().invoke("text").as("fileName")
 
-      // share file to newly created share folder
+      // share file to newly created shared folder
       homePage.fileItemKebabButton().click()
       homePage.shareMenuOption().click()
       shareFileModal.body().should("be.visible")
@@ -208,11 +208,11 @@ describe("File Sharing", () => {
     it("can move a file to a new shared folder and delete original", () => {
       cy.web3Login({ deleteShareBucket: true, clearCSFBucket: true })
 
-      // upload a file and store it's name as cypress alias
+      // upload a file and store its name as cypress alias
       homePage.uploadFile("../fixtures/uploadedFiles/logo.png")
       homePage.fileItemName().invoke("text").as("fileName")
 
-      // share file to newly created share folder
+      // share file to newly created shared folder
       homePage.fileItemKebabButton().click()
       homePage.shareMenuOption().click()
       shareFileModal.body().should("be.visible")
@@ -247,12 +247,12 @@ describe("File Sharing", () => {
       navigationMenu.sharedNavButton().click()
       sharedPage.createSharedFolder()
 
-      // upload a file and store it's name as cypress alias
+      // upload a file and store its name as cypress alias
       navigationMenu.homeNavButton().click()
       homePage.uploadFile("../fixtures/uploadedFiles/logo.png")
       homePage.fileItemName().invoke("text").as("fileName")
 
-      // share file to newly created share folder
+      // share file to newly created shared folder
       homePage.fileItemKebabButton().click()
       homePage.shareMenuOption().click()
       shareFileModal.body().should("be.visible")
@@ -285,12 +285,12 @@ describe("File Sharing", () => {
       navigationMenu.sharedNavButton().click()
       sharedPage.createSharedFolder()
 
-      // upload a file and store it's name as cypress alias
+      // upload a file and store its name as cypress alias
       navigationMenu.homeNavButton().click()
       homePage.uploadFile("../fixtures/uploadedFiles/logo.png")
       homePage.fileItemName().invoke("text").as("fileName")
 
-      // share file to newly created share folder
+      // share file to newly created shared folder
       homePage.fileItemKebabButton().click()
       homePage.shareMenuOption().click()
       shareFileModal.body().should("be.visible")

--- a/packages/files-ui/cypress/tests/file-sharing-spec.ts
+++ b/packages/files-ui/cypress/tests/file-sharing-spec.ts
@@ -225,17 +225,17 @@ describe("File Sharing", () => {
       shareSuccessToast.closeButton().click()
       editSharedFolderModal.closeButton().click()
 
-      // ensure the file did not remain in the drive after copying
+      // ensure the file did not remain in the drive after moving
       homePage.fileItemRow().should("have.length", 0)
 
-      // go to the new share and ensure the file was copied there
+      // go to the new share and ensure the file was moved there
       navigationMenu.sharedNavButton().click()
       sharedPage.sharedFolderItemName().contains(sharedFolderName)
         .should("be.visible")
         .dblclick()
       sharedPage.fileItemRow().should("have.length", 1)
 
-      // ensure file name of copied file is correct
+      // ensure file name of moved file is correct
       cy.get("@fileName").then(($fileName) => {
         sharedPage.fileItemName().contains(`${$fileName}`).should("be.visible")
       })
@@ -302,17 +302,17 @@ describe("File Sharing", () => {
       shareSuccessToast.body().should("be.visible")
       shareSuccessToast.closeButton().click()
 
-      // ensure file was deleted from drive after copying
+      // ensure file was deleted from drive after moving
       homePage.fileItemRow().should("have.length", 0)
 
-      // go to the new share and ensure file was copied there
+      // go to the new share and ensure file was moved there
       navigationMenu.sharedNavButton().click()
       sharedPage.sharedFolderItemName().contains(sharedFolderName)
         .should("be.visible")
         .dblclick()
       sharedPage.fileItemRow().should("have.length", 1)
 
-      // ensure file name of copied file is correct
+      // ensure file name of moved file is correct
       cy.get("@fileName").then(($fileName) => {
         sharedPage.fileItemName().contains(`${$fileName}`).should("be.visible")
       })

--- a/packages/files-ui/cypress/tests/file-sharing-spec.ts
+++ b/packages/files-ui/cypress/tests/file-sharing-spec.ts
@@ -205,7 +205,7 @@ describe("File Sharing", () => {
       })
     })
 
-    it("can copy a file to a new shared folder and delete original", () => {
+    it("can move a file to a new shared folder and delete original", () => {
       cy.web3Login({ deleteShareBucket: true, clearCSFBucket: true })
 
       // upload a file and store it's name as cypress alias
@@ -219,7 +219,7 @@ describe("File Sharing", () => {
       shareFileModal.shareNameInput().type(sharedFolderName)
       // click to unmark checkbox, selected by default
       shareFileModal.keepOriginalFilesCheckbox().click()
-      shareFileModal.copyOverButton().click()
+      shareFileModal.moveOverButton().click()
       sharingProgressToast.body().should("be.visible")
       shareSuccessToast.body().should("be.visible")
       shareSuccessToast.closeButton().click()
@@ -228,7 +228,7 @@ describe("File Sharing", () => {
       // ensure the file did not remain in the drive after copying
       homePage.fileItemRow().should("have.length", 0)
 
-      // go to the new share and ensure file was copied there
+      // go to the new share and ensure the file was copied there
       navigationMenu.sharedNavButton().click()
       sharedPage.sharedFolderItemName().contains(sharedFolderName)
         .should("be.visible")
@@ -241,7 +241,7 @@ describe("File Sharing", () => {
       })
     })
 
-    it.only("can copy a file to a pre-existing shared folder and preserve original", () => {
+    it("can copy a file to a pre-existing shared folder and preserve original", () => {
       cy.web3Login({ deleteShareBucket: true, clearCSFBucket: true })
 
       navigationMenu.sharedNavButton().click()
@@ -257,10 +257,7 @@ describe("File Sharing", () => {
       homePage.shareMenuOption().click()
       shareFileModal.body().should("be.visible")
       shareFileModal.selectFolderInput().click()
-      shareFileModal.existingFolderInputOption()
-        .contains(sharedFolderName)
-        .click()
-      //shareFileModal.selectFolderInput().type(`${sharedFolderName}{enter}`)
+      shareFileModal.selectFolderInput().type(`${sharedFolderName}{enter}`)
       shareFileModal.copyOverButton().click()
       sharingProgressToast.body().should("be.visible")
       shareSuccessToast.body().should("be.visible")
@@ -282,7 +279,7 @@ describe("File Sharing", () => {
       })
     })
 
-    it("can copy a file to a pre-existing shared folder and delete original", () => {
+    it("can move a file to a pre-existing shared folder and delete original", () => {
       cy.web3Login({ deleteShareBucket: true, clearCSFBucket: true })
 
       navigationMenu.sharedNavButton().click()
@@ -298,9 +295,6 @@ describe("File Sharing", () => {
       homePage.shareMenuOption().click()
       shareFileModal.body().should("be.visible")
       shareFileModal.selectFolderInput().click()
-      // shareFileModal.existingFolderInputOption()
-      //   .contains(sharedFolderName)
-      //   .click()
       shareFileModal.selectFolderInput().type(`${sharedFolderName}{enter}`)
       shareFileModal.keepOriginalFilesCheckbox().click()
       shareFileModal.moveOverButton().click()
@@ -323,6 +317,5 @@ describe("File Sharing", () => {
         sharedPage.fileItemName().contains(`${$fileName}`).should("be.visible")
       })
     })
-
   })
 })

--- a/packages/files-ui/cypress/tests/file-sharing-spec.ts
+++ b/packages/files-ui/cypress/tests/file-sharing-spec.ts
@@ -200,8 +200,8 @@ describe("File Sharing", () => {
       sharedPage.fileItemRow().should("have.length", 1)
 
       // ensure file name of copied file is correct
-      cy.get("@fileName").then(($fileName) => {
-        sharedPage.fileItemName().contains(`${$fileName}`).should("be.visible")
+      cy.get<string>("@fileName").then((fileName) => {
+        sharedPage.fileItemName().contains(fileName).should("be.visible")
       })
     })
 
@@ -236,8 +236,8 @@ describe("File Sharing", () => {
       sharedPage.fileItemRow().should("have.length", 1)
 
       // ensure file name of moved file is correct
-      cy.get("@fileName").then(($fileName) => {
-        sharedPage.fileItemName().contains(`${$fileName}`).should("be.visible")
+      cy.get<string>("@fileName").then((fileName) => {
+        sharedPage.fileItemName().contains(fileName).should("be.visible")
       })
     })
 
@@ -274,8 +274,8 @@ describe("File Sharing", () => {
       sharedPage.fileItemRow().should("have.length", 1)
 
       // ensure file name of copied file is correct
-      cy.get("@fileName").then(($fileName) => {
-        sharedPage.fileItemName().contains(`${$fileName}`).should("be.visible")
+      cy.get<string>("@fileName").then((fileName) => {
+        sharedPage.fileItemName().contains(fileName).should("be.visible")
       })
     })
 
@@ -313,8 +313,8 @@ describe("File Sharing", () => {
       sharedPage.fileItemRow().should("have.length", 1)
 
       // ensure file name of moved file is correct
-      cy.get("@fileName").then(($fileName) => {
-        sharedPage.fileItemName().contains(`${$fileName}`).should("be.visible")
+      cy.get<string>("@fileName").then((fileName) => {
+        sharedPage.fileItemName().contains(fileName).should("be.visible")
       })
     })
   })

--- a/packages/files-ui/cypress/tests/search-spec.ts
+++ b/packages/files-ui/cypress/tests/search-spec.ts
@@ -37,12 +37,12 @@ describe("Search", () => {
       cy.go("back")
 
       // search for a specific file, ensure only 1 result is found
-      cy.get("@fileName").then(($fileName) => {
-        homePage.searchInput().type(`{selectall}{del}${$fileName}{enter}`)
+      cy.get<string>("@fileName").then((fileName) => {
+        homePage.searchInput().type(`{selectall}{del}${fileName}{enter}`)
         searchPage.fileItemRow()
           .should("be.visible")
           .should("have.length", 1)
-        searchPage.fileItemName().should("contain.text", $fileName)
+        searchPage.fileItemName().should("contain.text", fileName)
       })
     })
 

--- a/packages/files-ui/cypress/tests/subscription-plan-spec.ts
+++ b/packages/files-ui/cypress/tests/subscription-plan-spec.ts
@@ -79,8 +79,8 @@ describe("Subscription Plan", () => {
       settingsPage.defaultCardLabel().invoke("text").as("partialMaskedMastercard")
 
       // ensure the card number was updated by comparing cypress aliases
-      cy.get("@partialMaskedVisa").then(($partialMaskedVisa) => {
-        cy.get("@partialMaskedMastercard").should("not.equal", $partialMaskedVisa)
+      cy.get<string>("@partialMaskedVisa").then((partialMaskedVisa) => {
+        cy.get("@partialMaskedMastercard").should("not.equal", partialMaskedVisa)
       })
 
       // remove the card
@@ -262,8 +262,8 @@ describe("Subscription Plan", () => {
       planDetailsModal.totalCostLabel().invoke("text").as("yearlyBillingPrice")
 
       // price should update when switching to annual billing
-      cy.get("@monthlyBillingPrice").then(($monthlyBillingPrice) => {
-        cy.get("@yearlyBillingPrice").should("not.equal", $monthlyBillingPrice)
+      cy.get<string>("@monthlyBillingPrice").then((monthlyBillingPrice) => {
+        cy.get("@yearlyBillingPrice").should("not.equal", monthlyBillingPrice)
       })
     })
 
@@ -442,8 +442,8 @@ describe("Subscription Plan", () => {
         .invoke("text").as("proPlanName")
 
       // ensure the downgraded plan name is not the same as the previously upgraded plan
-      cy.get("@premiumPlanName").then(($premiumPlanName) => {
-        cy.get("@proPlanName").should("not.equal", $premiumPlanName)
+      cy.get<string>("@premiumPlanName").then((premiumPlanName) => {
+        cy.get("@proPlanName").should("not.equal", premiumPlanName)
       })
     })
 
@@ -486,8 +486,8 @@ describe("Subscription Plan", () => {
         .invoke("text").as("freePlanName")
 
       // ensure the downgraded plan name is not the same as the previously upgraded plan
-      cy.get("@proPlanName").then(($standardPlanName) => {
-        cy.get("@freePlanName").should("not.equal", $standardPlanName)
+      cy.get<string>("@proPlanName").then((standardPlanName) => {
+        cy.get("@freePlanName").should("not.equal", standardPlanName)
       })
     })
 

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/ManageSharedFolder.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/ManageSharedFolder.tsx
@@ -417,7 +417,7 @@ const ManageSharedFolder = ({ onClose, bucketToEdit }: ICreateOrManageSharedFold
             size="large"
             variant="outline"
             type="button"
-            data-cy="button-cancel-create-shared-folder"
+            data-cy="button-close-manage-shared-folder"
           >
             <Trans>Close</Trans>
           </CustomButton>

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/ShareModal.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/ShareModal.tsx
@@ -288,8 +288,8 @@ const ShareModal = ({ onClose, fileSystemItems }: IShareModalProps) => {
                     labelClassName={classes.inputLabel}
                     options={bucketsOptions}
                     value={destinationBucket?.id}
-                    data-cy="input-existing-folder"
                     onChange={(val: string) => setDestinationBucket(buckets.find((bu) => bu.id === val))}
+                    data-cy="input-select-existing-folder-option"
                   />
                 </div>
               )

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/ShareModal.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/ShareModal.tsx
@@ -255,6 +255,7 @@ const ShareModal = ({ onClose, fileSystemItems }: IShareModalProps) => {
       active={true}
       closePosition="none"
       maxWidth={500}
+      testId="share-file"
     >
       {bucketToUpload
         ? <ManageSharedFolder
@@ -278,12 +279,16 @@ const ShareModal = ({ onClose, fileSystemItems }: IShareModalProps) => {
           <div className={classes.modalFlexItem}>
             {isUsingExistingBucket
               ? (
-                <div className={clsx(classes.modalFlexItem, classes.inputWrapper)}>
+                <div
+                  className={clsx(classes.modalFlexItem, classes.inputWrapper)}
+                  data-cy="input-select-existing-folder"
+                >
                   <SelectInput
                     label={t`Select an existing shared folder or your home`}
                     labelClassName={classes.inputLabel}
                     options={bucketsOptions}
                     value={destinationBucket?.id}
+                    data-cy="input-existing-folder"
                     onChange={(val: string) => setDestinationBucket(buckets.find((bu) => bu.id === val))}
                   />
                 </div>
@@ -300,6 +305,7 @@ const ShareModal = ({ onClose, fileSystemItems }: IShareModalProps) => {
                     autoFocus
                     onChange={onNameChange}
                     state={nameError ? "error" : "normal"}
+                    data-cy="input-new-share-name"
                   />
                   {!!nameError && (
                     <Typography
@@ -340,6 +346,7 @@ const ShareModal = ({ onClose, fileSystemItems }: IShareModalProps) => {
                     setKeepOriginalFile(!keepOriginalFile)
                   }}
                   label={t`Keep original files`}
+                  testId="keep-original-files"
                 />
               </div>
             )}
@@ -348,6 +355,7 @@ const ShareModal = ({ onClose, fileSystemItems }: IShareModalProps) => {
                 variant="outline"
                 onClick={onClose}
                 className={classes.cancelButton}
+                testId="cancel-share-file"
               >
                 <Trans>Cancel</Trans>
               </Button>
@@ -361,6 +369,7 @@ const ShareModal = ({ onClose, fileSystemItems }: IShareModalProps) => {
                   ? !destinationBucket?.id
                   : !sharedFolderName || !!nameError
                 }
+                testId={keepOriginalFile ? "copy-over" : "move-over"}
               >
                 {keepOriginalFile
                   ? <Trans>Copy over</Trans>

--- a/packages/files-ui/src/Contexts/FilesContext.tsx
+++ b/packages/files-ui/src/Contexts/FilesContext.tsx
@@ -803,7 +803,8 @@ const FilesProvider = ({ children }: FilesContextProps) => {
                   updateToast(toastId, {
                     title: t`${inSharedBucket ? "Copying" : "Sharing"} ${fileProgress} - ${item.name}`,
                     type: "success",
-                    progress: currentProgress
+                    progress: currentProgress,
+                    testId: "sharing-progress"
                   })
                 },
                 cancelToken
@@ -829,6 +830,7 @@ const FilesProvider = ({ children }: FilesContextProps) => {
               : t`${inSharedBucket ? "Copying" : "Sharing"} failed`,
           type: successCount ? "success" : "error",
           progress: undefined,
+          testId: "share-success",
           isClosable: true
         }, true)
         setTransfersInProgress(false)


### PR DESCRIPTION
closes #2029

adds coverage for the 4 scenarios when copying / moving files to new / existing shares and preserving / deleting the original