### PR TITLE
Prevent multiple file/folder renames [storage]

### DIFF
--- a/packages/storage-ui/src/Components/Modules/FileSystemItem/FileSystemGridItem.tsx
+++ b/packages/storage-ui/src/Components/Modules/FileSystemItem/FileSystemGridItem.tsx
@@ -234,6 +234,7 @@ const FileSystemGridItem = React.forwardRef(
           >
             {icon}
           </div>
+          // checking the name is useful for MFS folders since empty folders all have the same cid
           {editing?.cid === cid && editing.name === name && desktop ? (
             <FormikProvider value={formik}>
               <Form

--- a/packages/storage-ui/src/Components/Modules/FileSystemItem/FileSystemGridItem.tsx
+++ b/packages/storage-ui/src/Components/Modules/FileSystemItem/FileSystemGridItem.tsx
@@ -130,12 +130,12 @@ interface IFileSystemTableItemProps {
   isOverUpload: boolean
   selected: ISelectedFile[]
   file: FileSystemItem
-  editing?: string
+  editing?: ISelectedFile
   onFolderOrFileClicks: (e?: React.MouseEvent) => void
   icon: React.ReactNode
   preview: ConnectDragPreview
   setEditing: (editing: ISelectedFile |  undefined) => void
-  handleRename?: (cid: string, newName: string) => Promise<void> | undefined
+  handleRename?: (item: ISelectedFile, newName: string) => Promise<void> | undefined
   currentPath: string | undefined
   menuItems: IMenuItem[]
   resetSelectedFiles: () => void
@@ -170,10 +170,10 @@ const FileSystemGridItem = React.forwardRef(
       onSubmit: (values) => {
         const newName = values.fileName?.trim()
 
-        if (newName !== name && !!newName && handleRename) {
+        if (newName !== name && !!newName && handleRename && editing) {
           setIsEditingLoading(true)
 
-          handleRename(file.cid, newName)
+          handleRename(editing, newName)
             ?.then(() => setIsEditingLoading(false))
         } else {
           stopEditing()
@@ -234,7 +234,7 @@ const FileSystemGridItem = React.forwardRef(
           >
             {icon}
           </div>
-          {editing === cid && desktop ? (
+          {editing?.cid === cid && editing.name === name && desktop ? (
             <FormikProvider value={formik}>
               <Form
                 className={classes.desktopRename}

--- a/packages/storage-ui/src/Components/Modules/FileSystemItem/FileSystemGridItem.tsx
+++ b/packages/storage-ui/src/Components/Modules/FileSystemItem/FileSystemGridItem.tsx
@@ -130,11 +130,11 @@ interface IFileSystemTableItemProps {
   isOverUpload: boolean
   selected: ISelectedFile[]
   file: FileSystemItem
-  editing?: ISelectedFile
+  editingFile?: ISelectedFile
   onFolderOrFileClicks: (e?: React.MouseEvent) => void
   icon: React.ReactNode
   preview: ConnectDragPreview
-  setEditing: (editing: ISelectedFile |  undefined) => void
+  setEditingFile: (editingFile: ISelectedFile |  undefined) => void
   handleRename?: (item: ISelectedFile, newName: string) => Promise<void> | undefined
   currentPath: string | undefined
   menuItems: IMenuItem[]
@@ -148,10 +148,10 @@ const FileSystemGridItem = React.forwardRef(
     isOverUpload,
     selected,
     file,
-    editing,
+    editingFile,
     onFolderOrFileClicks,
     icon,
-    setEditing,
+    setEditingFile,
     handleRename,
     menuItems,
     resetSelectedFiles,
@@ -170,10 +170,10 @@ const FileSystemGridItem = React.forwardRef(
       onSubmit: (values) => {
         const newName = values.fileName?.trim()
 
-        if (newName !== name && !!newName && handleRename && editing) {
+        if (newName !== name && !!newName && handleRename && editingFile) {
           setIsEditingLoading(true)
 
-          handleRename(editing, newName)
+          handleRename(editingFile, newName)
             ?.then(() => setIsEditingLoading(false))
         } else {
           stopEditing()
@@ -205,9 +205,9 @@ const FileSystemGridItem = React.forwardRef(
     }, [handleClickOutside])
 
     const stopEditing = useCallback(() => {
-      setEditing(undefined)
+      setEditingFile(undefined)
       formik.resetForm()
-    }, [formik, setEditing])
+    }, [formik, setEditingFile])
 
     return  (
       <div
@@ -234,7 +234,7 @@ const FileSystemGridItem = React.forwardRef(
           >
             {icon}
           </div>
-          {editing?.cid === cid && editing.name === name && desktop ? (
+          {editingFile?.cid === cid && editingFile.name === name && desktop ? (
             <FormikProvider value={formik}>
               <Form
                 className={classes.desktopRename}

--- a/packages/storage-ui/src/Components/Modules/FileSystemItem/FileSystemItem.tsx
+++ b/packages/storage-ui/src/Components/Modules/FileSystemItem/FileSystemItem.tsx
@@ -107,9 +107,9 @@ interface IFileSystemItemProps {
   selected: ISelectedFile[]
   handleSelectCid(selectedFile: ISelectedFile): void
   handleAddToSelectedCids(selectedFile: ISelectedFile): void
-  editing?: string
+  editing?: ISelectedFile
   setEditing(editing: ISelectedFile | undefined): void
-  handleRename?: (cid: string, newName: string) => Promise<void> | undefined
+  handleRename?: (item: ISelectedFile, newName: string) => Promise<void> | undefined
   handleMove?: (toMove: ISelectedFile, newPath: string) => Promise<void>
   deleteFile?: () => void
   recoverFile?: (toRecover: ISelectedFile) => void
@@ -429,7 +429,7 @@ const FileSystemItem = ({
           : <FileItemGridItem {...itemProps} />
       }
       {
-        editing === cid && !desktop && (
+        editing?.cid === cid && editing?.name === name && !desktop && (
           <>
             <CustomModal
               className={classes.modalRoot}

--- a/packages/storage-ui/src/Components/Modules/FileSystemItem/FileSystemItem.tsx
+++ b/packages/storage-ui/src/Components/Modules/FileSystemItem/FileSystemItem.tsx
@@ -107,8 +107,8 @@ interface IFileSystemItemProps {
   selected: ISelectedFile[]
   handleSelectCid(selectedFile: ISelectedFile): void
   handleAddToSelectedCids(selectedFile: ISelectedFile): void
-  editing?: ISelectedFile
-  setEditing(editing: ISelectedFile | undefined): void
+  editingFile?: ISelectedFile
+  setEditingFile(editingFile: ISelectedFile | undefined): void
   handleRename?: (item: ISelectedFile, newName: string) => Promise<void> | undefined
   handleMove?: (toMove: ISelectedFile, newPath: string) => Promise<void>
   deleteFile?: () => void
@@ -126,8 +126,8 @@ const FileSystemItem = ({
   file,
   files,
   selected,
-  editing,
-  setEditing,
+  editingFile,
+  setEditingFile,
   handleRename,
   deleteFile,
   recoverFile,
@@ -163,7 +163,7 @@ const FileSystemItem = ({
     onSubmit: (values: {name: string}) => {
       const newName = values.name.trim()
 
-      editing && newName && handleRename && handleRename(editing, newName)
+      editingFile && newName && handleRename && handleRename(editingFile, newName)
     },
     enableReinitialize: true
   })
@@ -178,7 +178,7 @@ const FileSystemItem = ({
           </span>
         </>
       ),
-      onClick: () => setEditing({ cid, name })
+      onClick: () => setEditingFile({ cid, name })
     },
     delete: {
       contents: (
@@ -333,11 +333,11 @@ const FileSystemItem = ({
 
   const fileOrFolderRef = useRef<any>()
 
-  if (!editing && isFolder) {
+  if (!editingFile && isFolder) {
     dropMoveRef(fileOrFolderRef)
     dropUploadRef(fileOrFolderRef)
   }
-  if (!editing && !isFolder) {
+  if (!editingFile && !isFolder) {
     dragMoveRef(fileOrFolderRef)
   }
 
@@ -405,7 +405,7 @@ const FileSystemItem = ({
   const itemProps = {
     ref: fileOrFolderRef,
     currentPath,
-    editing,
+    editingFile,
     file,
     handleAddToSelectedCids,
     handleRename,
@@ -417,7 +417,7 @@ const FileSystemItem = ({
     onFolderOrFileClicks,
     preview,
     selected,
-    setEditing,
+    setEditingFile,
     resetSelectedFiles
   }
 
@@ -429,7 +429,7 @@ const FileSystemItem = ({
           : <FileItemGridItem {...itemProps} />
       }
       {
-        editing?.cid === cid && editing?.name === name && !desktop && (
+        editingFile?.cid === cid && editingFile?.name === name && !desktop && (
           <>
             <CustomModal
               className={classes.modalRoot}
@@ -437,7 +437,7 @@ const FileSystemItem = ({
                 inner: classes.modalInner
               }}
               closePosition="none"
-              onClose={() => setEditing(undefined)}
+              onClose={() => setEditingFile(undefined)}
             >
               <FormikProvider value={formik}>
                 <Form className={classes.renameModal}>
@@ -460,7 +460,7 @@ const FileSystemItem = ({
                   />
                   <footer className={classes.renameFooter}>
                     <Button
-                      onClick={() => setEditing(undefined)}
+                      onClick={() => setEditingFile(undefined)}
                       size="medium"
                       className={classes.cancelButton}
                       variant="outline"

--- a/packages/storage-ui/src/Components/Modules/FileSystemItem/FileSystemTableItem.tsx
+++ b/packages/storage-ui/src/Components/Modules/FileSystemItem/FileSystemTableItem.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useState } from "react"
-import { makeStyles, createStyles, useThemeSwitcher, debounce } from "@chainsafe/common-theme"
+import React, { useCallback, useRef, useState } from "react"
+import { makeStyles, createStyles, useThemeSwitcher, debounce, useOnClickOutside } from "@chainsafe/common-theme"
 import { t, Trans } from "@lingui/macro"
 import clsx from "clsx"
 import {
@@ -214,12 +214,11 @@ const FileSystemTableItem = React.forwardRef(
     const { fileSystemType } = useFileBrowser()
     const { name, cid, size } = file
     const { desktop } = useThemeSwitcher()
+    const formRef = useRef(null)
     const [isEditingLoading, setIsEditingLoading] = useState(false)
 
     const formik = useFormik({
-      initialValues: {
-        name: name
-      },
+      initialValues: { name: name },
       validationSchema: nameValidator,
       onSubmit: (values) => {
         const newName = values.name?.trim()
@@ -229,6 +228,8 @@ const FileSystemTableItem = React.forwardRef(
 
           handleRename(editing, newName)
             ?.then(() => setIsEditingLoading(false))
+        } else {
+          setEditing(undefined)
         }
       },
       enableReinitialize: true
@@ -238,6 +239,8 @@ const FileSystemTableItem = React.forwardRef(
       setEditing(undefined)
       formik.resetForm()
     }, [formik, setEditing])
+
+    useOnClickOutside(formRef, formik.submitForm)
 
     const [copied, setCopied] = useState(false)
     const debouncedSwitchCopied = debounce(() => setCopied(false), 3000)
@@ -291,6 +294,7 @@ const FileSystemTableItem = React.forwardRef(
                   className={classes.desktopRename}
                   onBlur={formik.submitForm}
                   data-cy='form-rename'
+                  ref={formRef}
                 >
                   <FormikTextInput
                     className={classes.renameInput}

--- a/packages/storage-ui/src/Components/Modules/FileSystemItem/FileSystemTableItem.tsx
+++ b/packages/storage-ui/src/Components/Modules/FileSystemItem/FileSystemTableItem.tsx
@@ -292,7 +292,6 @@ const FileSystemTableItem = React.forwardRef(
               <FormikProvider value={formik}>
                 <Form
                   className={classes.desktopRename}
-                  onBlur={formik.submitForm}
                   data-cy='form-rename'
                   ref={formRef}
                 >

--- a/packages/storage-ui/src/Components/Modules/FileSystemItem/FileSystemTableItem.tsx
+++ b/packages/storage-ui/src/Components/Modules/FileSystemItem/FileSystemTableItem.tsx
@@ -287,6 +287,7 @@ const FileSystemTableItem = React.forwardRef(
           className={clsx(classes.filename, desktop && editing?.cid === cid && editing.name === name && "editing")}
           onClick={(e) => !editing && onFolderOrFileClicks(e)}
         >
+           // checking the name is useful for MFS folders since empty folders all have the same cid
           {editing?.cid === cid && editing.name === name && desktop
             ? (
               <FormikProvider value={formik}>

--- a/packages/storage-ui/src/Components/Modules/FileSystemItem/FileSystemTableItem.tsx
+++ b/packages/storage-ui/src/Components/Modules/FileSystemItem/FileSystemTableItem.tsx
@@ -183,12 +183,12 @@ interface IFileSystemTableItemProps {
   isOverUpload: boolean
   selected: ISelectedFile[]
   file: FileSystemItem
-  editing?: ISelectedFile
+  editingFile?: ISelectedFile
   handleAddToSelectedCids: (selected: ISelectedFile) => void
   onFolderOrFileClicks: (e?: React.MouseEvent) => void
   icon: React.ReactNode
   preview: ConnectDragPreview
-  setEditing: (editing: ISelectedFile |  undefined) => void
+  setEditingFile: (editingFile: ISelectedFile |  undefined) => void
   handleRename?: (item: ISelectedFile, newName: string) => Promise<void> | undefined
   currentPath: string | undefined
   menuItems: IMenuItem[]
@@ -201,12 +201,12 @@ const FileSystemTableItem = React.forwardRef(
     isOverUpload,
     selected,
     file,
-    editing,
+    editingFile,
     handleAddToSelectedCids,
     onFolderOrFileClicks,
     icon,
     preview,
-    setEditing,
+    setEditingFile,
     handleRename,
     menuItems
   }: IFileSystemTableItemProps, forwardedRef: any) => {
@@ -223,22 +223,22 @@ const FileSystemTableItem = React.forwardRef(
       onSubmit: (values) => {
         const newName = values.name?.trim()
 
-        if (newName !== name && !!newName && handleRename && editing) {
+        if (newName !== name && !!newName && handleRename && editingFile) {
           setIsEditingLoading(true)
 
-          handleRename(editing, newName)
+          handleRename(editingFile, newName)
             ?.then(() => setIsEditingLoading(false))
         } else {
-          setEditing(undefined)
+          setEditingFile(undefined)
         }
       },
       enableReinitialize: true
     })
 
     const stopEditing = useCallback(() => {
-      setEditing(undefined)
+      setEditingFile(undefined)
       formik.resetForm()
-    }, [formik, setEditing])
+    }, [formik, setEditingFile])
 
     useOnClickOutside(formRef, formik.submitForm)
 
@@ -284,10 +284,10 @@ const FileSystemTableItem = React.forwardRef(
           data-cy="label-file-item-name"
           ref={preview}
           align="left"
-          className={clsx(classes.filename, desktop && editing?.cid === cid && editing.name === name && "editing")}
-          onClick={(e) => !editing && onFolderOrFileClicks(e)}
+          className={clsx(classes.filename, desktop && editingFile?.cid === cid && editingFile.name === name && "editing")}
+          onClick={(e) => !editingFile && onFolderOrFileClicks(e)}
         >
-          {editing?.cid === cid && editing.name === name && desktop
+          {editingFile?.cid === cid && editingFile.name === name && desktop
             ? (
               <FormikProvider value={formik}>
                 <Form

--- a/packages/storage-ui/src/Components/Modules/FileSystemItem/FileSystemTableItem.tsx
+++ b/packages/storage-ui/src/Components/Modules/FileSystemItem/FileSystemTableItem.tsx
@@ -183,13 +183,13 @@ interface IFileSystemTableItemProps {
   isOverUpload: boolean
   selected: ISelectedFile[]
   file: FileSystemItem
-  editing?: string
+  editing?: ISelectedFile
   handleAddToSelectedCids: (selected: ISelectedFile) => void
   onFolderOrFileClicks: (e?: React.MouseEvent) => void
   icon: React.ReactNode
   preview: ConnectDragPreview
   setEditing: (editing: ISelectedFile |  undefined) => void
-  handleRename?: (cid: string, newName: string) => Promise<void> | undefined
+  handleRename?: (item: ISelectedFile, newName: string) => Promise<void> | undefined
   currentPath: string | undefined
   menuItems: IMenuItem[]
 }
@@ -224,10 +224,10 @@ const FileSystemTableItem = React.forwardRef(
       onSubmit: (values) => {
         const newName = values.name?.trim()
 
-        if (newName !== name && !!newName && handleRename) {
+        if (newName !== name && !!newName && handleRename && editing) {
           setIsEditingLoading(true)
 
-          handleRename(cid, newName)
+          handleRename(editing, newName)
             ?.then(() => setIsEditingLoading(false))
         }
       },
@@ -281,10 +281,10 @@ const FileSystemTableItem = React.forwardRef(
           data-cy="label-file-item-name"
           ref={preview}
           align="left"
-          className={clsx(classes.filename, desktop && editing === cid && "editing")}
+          className={clsx(classes.filename, desktop && editing?.cid === cid && editing.name === name && "editing")}
           onClick={(e) => !editing && onFolderOrFileClicks(e)}
         >
-          {editing === cid && desktop
+          {editing?.cid === cid && editing.name === name && desktop
             ? (
               <FormikProvider value={formik}>
                 <Form

--- a/packages/storage-ui/src/Components/Modules/FilesList/FilesList.tsx
+++ b/packages/storage-ui/src/Components/Modules/FilesList/FilesList.tsx
@@ -334,7 +334,7 @@ const FilesList = () => {
     withSurvey
   } = useFileBrowser()
   const classes = useStyles({ themeKey })
-  const [editing, setEditing] = useState<ISelectedFile | undefined>()
+  const [editingFile, setEditingFile] = useState<ISelectedFile | undefined>()
   const [direction, setDirection] = useState<SortDirection>("ascend")
   const [column, setColumn] = useState<"name" | "size" | "date_uploaded">("name")
   const [selectedCids, setSelectedCids] = useState<ISelectedFile[]>([])
@@ -880,10 +880,10 @@ const FilesList = () => {
                 selected={selectedCids}
                 handleSelectCid={handleSelectCid}
                 handleAddToSelectedCids={handleAddToSelectedCids}
-                editing={editing}
-                setEditing={setEditing}
+                editingFile={editingFile}
+                setEditingFile={setEditingFile}
                 handleRename={(item: ISelectedFile, newName: string) => {
-                  setEditing(undefined)
+                  setEditingFile(undefined)
                   return handleRename && handleRename(item, newName)
                 }}
                 deleteFile={() => {
@@ -936,11 +936,11 @@ const FilesList = () => {
               handleSelectCid={handleSelectCid}
               viewFolder={handleViewFolder}
               handleAddToSelectedCids={handleAddToSelectedCids}
-              editing={editing}
-              setEditing={setEditing}
-              handleRename={(editing: ISelectedFile, newName: string) => {
-                setEditing(undefined)
-                return handleRename && handleRename(editing, newName)
+              editingFile={editingFile}
+              setEditingFile={setEditingFile}
+              handleRename={(editingFile: ISelectedFile, newName: string) => {
+                setEditingFile(undefined)
+                return handleRename && handleRename(editingFile, newName)
               }}
               deleteFile={() => {
                 setSelectedCids([{

--- a/packages/storage-ui/src/Components/Modules/FilesList/FilesList.tsx
+++ b/packages/storage-ui/src/Components/Modules/FilesList/FilesList.tsx
@@ -880,11 +880,11 @@ const FilesList = () => {
                 selected={selectedCids}
                 handleSelectCid={handleSelectCid}
                 handleAddToSelectedCids={handleAddToSelectedCids}
-                editing={editing?.cid}
+                editing={editing}
                 setEditing={setEditing}
-                handleRename={(cid: string, newName: string) => {
+                handleRename={(item: ISelectedFile, newName: string) => {
                   setEditing(undefined)
-                  return handleRename && handleRename(cid, newName)
+                  return handleRename && handleRename(item, newName)
                 }}
                 deleteFile={() => {
                   setSelectedCids([{
@@ -936,11 +936,11 @@ const FilesList = () => {
               handleSelectCid={handleSelectCid}
               viewFolder={handleViewFolder}
               handleAddToSelectedCids={handleAddToSelectedCids}
-              editing={editing?.cid}
+              editing={editing}
               setEditing={setEditing}
-              handleRename={(cid: string, newName: string) => {
+              handleRename={(editing: ISelectedFile, newName: string) => {
                 setEditing(undefined)
-                return handleRename && handleRename(cid, newName)
+                return handleRename && handleRename(editing, newName)
               }}
               deleteFile={() => {
                 setSelectedCids([{

--- a/packages/storage-ui/src/Components/Pages/BucketPage.tsx
+++ b/packages/storage-ui/src/Components/Pages/BucketPage.tsx
@@ -97,8 +97,8 @@ const BucketPage: React.FC<IFileBrowserModuleProps> = () => {
       .finally(refreshContents)
   }, [bucket, storageApiClient, refreshContents, pathContents, currentPath, addToast])
 
-  const renameItem = useCallback(async (cid: string, newName: string) => {
-    const itemToRename = pathContents.find(i => i.cid === cid)
+  const renameItem = useCallback(async (item: ISelectedFile, newName: string) => {
+    const itemToRename = pathContents.find(i => i.cid === item.cid && i.name === item.name)
     if (!bucket || !itemToRename) return
 
     return storageApiClient.moveBucketObjects(bucket.id, {

--- a/packages/storage-ui/src/Components/Pages/BucketPage.tsx
+++ b/packages/storage-ui/src/Components/Pages/BucketPage.tsx
@@ -98,6 +98,7 @@ const BucketPage: React.FC<IFileBrowserModuleProps> = () => {
   }, [bucket, storageApiClient, refreshContents, pathContents, currentPath, addToast])
 
   const renameItem = useCallback(async (item: ISelectedFile, newName: string) => {
+     // checking the name is useful for MFS folders since empty folders all have the same cid
     const itemToRename = pathContents.find(i => i.cid === item.cid && i.name === item.name)
     if (!bucket || !itemToRename) return
 

--- a/packages/storage-ui/src/Contexts/FileBrowserContext.tsx
+++ b/packages/storage-ui/src/Contexts/FileBrowserContext.tsx
@@ -13,7 +13,7 @@ interface FileBrowserContext extends IFileBrowserModuleProps {
   bucket?: Bucket
   itemOperations: {[contentType: string]: FileOperation[]}
   bulkOperations?: IBulkOperations
-  renameItem?: (cid: string, newName: string) => Promise<void>
+  renameItem?: (item: ISelectedFile, newName: string) => Promise<void>
   moveItems?: (toMove: ISelectedFile[], newPath: string) => Promise<void>
   downloadFile?: (toDownload: ISelectedFile) => Promise<void>
   deleteItems?: (toDelete: ISelectedFile[]) => Promise<void>


### PR DESCRIPTION
closes #2089

Also added the on click outside with rename fields in storage.

---
Submission checklist: 

<!-- Remove anything below that is not applicable -->   

#### Layout
- [x] Change looks good in the desktop web ui

#### Theme
- [x] Components / elements inspected in light mode

