### PR TITLE
Fix double slash when uploading a file

### DIFF
--- a/packages/files-ui/src/Components/Modules/FileBrowsers/UploadFileModal.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/UploadFileModal.tsx
@@ -81,9 +81,8 @@ interface IUploadFileModuleProps {
 const UploadFileModule = ({ modalOpen, close }: IUploadFileModuleProps) => {
   const classes = useStyles()
   const [isDoneDisabled, setIsDoneDisabled] = useState(true)
-  const { uploadFiles } = useFiles()
   const { currentPath, refreshContents, bucket } = useFileBrowser()
-  const { storageSummary } = useFiles()
+  const { storageSummary, uploadFiles } = useFiles()
 
   const UploadSchema = useMemo(() => object().shape({
     files: array().required(t`Please select a file to upload`)
@@ -105,10 +104,13 @@ const UploadFileModule = ({ modalOpen, close }: IUploadFileModuleProps) => {
 
   const onSubmit = useCallback(async (values: {files: Array<File & {path: string}>}, helpers) => {
     if (!bucket) return
+
     helpers.setSubmitting(true)
+
     try {
       close()
       const paths = [...new Set(values.files.map(f => f.path.substring(0, f.path.lastIndexOf("/"))))]
+
       paths.forEach(async p => {
         const filesToUpload = values.files.filter((f => f.path.substring(0, f.path.lastIndexOf("/")) === p))
         await uploadFiles(bucket, filesToUpload, getPathWithFile(currentPath, p))
@@ -124,7 +126,7 @@ const UploadFileModule = ({ modalOpen, close }: IUploadFileModuleProps) => {
   const formik = useFormik({
     initialValues: { files: [] },
     validationSchema: UploadSchema,
-    onSubmit: onSubmit
+    onSubmit
   })
 
   return (
@@ -132,9 +134,7 @@ const UploadFileModule = ({ modalOpen, close }: IUploadFileModuleProps) => {
       active={modalOpen}
       closePosition="none"
       maxWidth="sm"
-      injectedClass={{
-        inner: classes.modalInner
-      }}
+      injectedClass={{ inner: classes.modalInner }}
     >
       <FormikProvider value={formik}>
         <Form

--- a/packages/files-ui/src/Utils/pathUtils.ts
+++ b/packages/files-ui/src/Utils/pathUtils.ts
@@ -43,11 +43,18 @@ export function getURISafePathFromArray(arrayOfPaths: string[]): string {
 // /path/to/somewhere + 1.txt -> /path/to/somewhere/1.txt
 // /path/to/somewhere/ + 1.txt -> /path/to/somewhere/1.txt
 export function getPathWithFile(path: string, fileName: string) {
+
+  // make sure the file name doesn't start with a /
+  // otherwise remove it
+  const nameToUse = fileName.startsWith("/")
+    ? fileName.substring(1)
+    : fileName
+
   return path === "/"
-    ? `/${fileName}`
+    ? `/${nameToUse}`
     : path[path.length - 1] === "/"
-      ? `${path}${fileName}`
-      : `${path}/${fileName}`
+      ? `${path}${nameToUse}`
+      : `${path}/${nameToUse}`
 }
 
 // Removes a parent element


### PR DESCRIPTION
I feel we've seen this issue before, reported by Andrew. As I was debugging something else, I found out why it happens.
How to reproduce:
- click on upload
- drag a folder with files 
- check the POST upload path and see that the path is `//some dir/some-file` with a double slash

This should fix it. 

@asnaith although I think this is a pretty safe change IMHO, this helper function is used a lot, and it is potentially breaking things. I've spent quite some time to test things, it's used in the preview overview, move files, create directories etc.. 