### PR TITLE
Extend timeout to improve storage test reliability

### DIFF
--- a/packages/storage-ui/cypress/support/page-objects/bucketsPage.ts
+++ b/packages/storage-ui/cypress/support/page-objects/bucketsPage.ts
@@ -7,7 +7,7 @@ export const bucketsPage = {
   ...basePage,
 
   // main bucket browser elements
-  bucketsHeaderLabel: () => cy.get("[data-cy=header-buckets]"),
+  bucketsHeaderLabel: () => cy.get("[data-cy=header-buckets]", { timeout: 20000 }),
   createBucketButton: () => cy.get("[data-cy=button-create-bucket]"),
 
   // bucket browser row elements


### PR DESCRIPTION
Just a quick one liner -

 I realized I was overzealous in another PR last week when I removed some timeouts. Re-adding this one as it caused a reliability issue with storage tests in CI (where network speed can be slower).