### PR TITLE
Fix context menu flash in Firefox

### DIFF
--- a/packages/files-ui/src/Components/Modules/FileBrowsers/views/FilesList.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/views/FilesList.tsx
@@ -767,23 +767,23 @@ const FilesList = ({ isShared = false }: Props) => {
     setIsSurveyBannerVisible(false)
   }, [setIsSurveyBannerVisible])
 
-  const onViewFolder = useCallback((file: FileSystemItemType) => {
+  const handleViewFolder = useCallback((file: FileSystemItemType) => {
     !loadingCurrentPath && viewFolder && viewFolder(file.cid)
   }, [viewFolder, loadingCurrentPath])
 
-  const onOpenMoveFileDialog = useCallback((e: React.MouseEvent) => {
+  const handleOpenMoveFileDialog = useCallback((e: React.MouseEvent) => {
     e.preventDefault()
     e.stopPropagation()
     setIsMoveFileModalOpen(true)
   }, [])
 
-  const onOpenDeleteDialog = useCallback((e: React.MouseEvent) => {
+  const handleOpenDeleteDialog = useCallback((e: React.MouseEvent) => {
     e.preventDefault()
     e.stopPropagation()
     setIsDeleteModalOpen(true)
   }, [])
 
-  const onOpenShareDialog = useCallback((e?: React.MouseEvent) => {
+  const handleOpenShareDialog = useCallback((e?: React.MouseEvent) => {
     e?.preventDefault()
     e?.stopPropagation()
     setClickedShare(true)
@@ -792,8 +792,8 @@ const FilesList = ({ isShared = false }: Props) => {
 
   const onShare = useCallback((fileSystemItem: FileSystemItemType) => {
     setSelectedItems([fileSystemItem])
-    onOpenShareDialog()
-  }, [onOpenShareDialog])
+    handleOpenShareDialog()
+  }, [handleOpenShareDialog])
 
   const browserOptions = useMemo(() => [
     {
@@ -851,7 +851,7 @@ const FilesList = ({ isShared = false }: Props) => {
           </>
         ),
         onClick: (e: React.MouseEvent) => {
-          onOpenMoveFileDialog(e)
+          handleOpenMoveFileDialog(e)
           setMoveModalMode("move")
         }
       })
@@ -866,7 +866,7 @@ const FilesList = ({ isShared = false }: Props) => {
           </>
         ),
         onClick: (e: React.MouseEvent) => {
-          onOpenMoveFileDialog(e)
+          handleOpenMoveFileDialog(e)
           setMoveModalMode("recover")
         }
       })
@@ -880,7 +880,7 @@ const FilesList = ({ isShared = false }: Props) => {
             </span>
           </>
         ),
-        onClick: onOpenDeleteDialog
+        onClick: handleOpenDeleteDialog
       })
     validBulkOps.includes("share") &&
       menuOptions.push({
@@ -891,7 +891,7 @@ const FilesList = ({ isShared = false }: Props) => {
             </span>
           </>
         ),
-        onClick: onOpenShareDialog
+        onClick: handleOpenShareDialog
       })
 
     return menuOptions
@@ -900,9 +900,9 @@ const FilesList = ({ isShared = false }: Props) => {
     bucket,
     currentPath,
     downloadMultipleFiles,
-    onOpenDeleteDialog,
-    onOpenMoveFileDialog,
-    onOpenShareDialog,
+    handleOpenDeleteDialog,
+    handleOpenMoveFileDialog,
+    handleOpenShareDialog,
     resetSelectedItems,
     selectedItems,
     selectionContainsAFolder
@@ -939,12 +939,12 @@ const FilesList = ({ isShared = false }: Props) => {
     moveFile: onMoveFile,
     recoverFile: onRecoverFile,
     reportFile: onReportFile,
-    viewFolder: onViewFolder,
+    viewFolder: handleViewFolder,
     showFileInfo: onShowFileInfo,
     previewFile: onShowPreview,
     editFile: onEditFile
   }), [
-    onViewFolder,
+    handleViewFolder,
     onDeleteFile,
     onDownloadFile,
     onMoveFile,
@@ -1154,7 +1154,7 @@ const FilesList = ({ isShared = false }: Props) => {
               {validBulkOps.includes("move") && (
                 <Button
                   onClick={(e) => {
-                    onOpenMoveFileDialog(e)
+                    handleOpenMoveFileDialog(e)
                     setMoveModalMode("move")
                   }}
                   variant="outline"
@@ -1166,7 +1166,7 @@ const FilesList = ({ isShared = false }: Props) => {
               {validBulkOps.includes("recover") && (
                 <Button
                   onClick={(e) => {
-                    onOpenMoveFileDialog(e)
+                    handleOpenMoveFileDialog(e)
                     setMoveModalMode("recover")
                   }}
                   variant="outline"
@@ -1177,7 +1177,7 @@ const FilesList = ({ isShared = false }: Props) => {
               )}
               {validBulkOps.includes("delete") && (
                 <Button
-                  onClick={onOpenDeleteDialog}
+                  onClick={handleOpenDeleteDialog}
                   variant="outline"
                   testId="delete-selected-file"
                 >
@@ -1186,7 +1186,7 @@ const FilesList = ({ isShared = false }: Props) => {
               )}
               {validBulkOps.includes("share") && (
                 <Button
-                  onClick={onOpenShareDialog}
+                  onClick={handleOpenShareDialog}
                   variant="outline"
                   testId="share-selected-file"
                 >

--- a/packages/files-ui/src/UI-components/AnchorMenu.tsx
+++ b/packages/files-ui/src/UI-components/AnchorMenu.tsx
@@ -1,8 +1,10 @@
-import React, {  ReactNode, useEffect, useMemo, useRef } from "react"
+import React, {  ReactNode, useCallback, useEffect, useMemo, useRef } from "react"
 import { MenuItem, Paper, PopoverPosition } from "@material-ui/core"
 import { makeStyles, createStyles, useOnClickOutside } from "@chainsafe/common-theme"
 import clsx from "clsx"
 import { CSFTheme } from "../Themes/types"
+
+export type AnchoreMenuPosition = PopoverPosition;
 
 interface Option {
   contents: ReactNode
@@ -12,9 +14,8 @@ interface Option {
 }
 
 interface Props {
-  isOpen: boolean
   options: Option[]
-  anchorPosition?: PopoverPosition
+  anchorPosition?: AnchoreMenuPosition
   onClose: () => void
 }
 
@@ -35,13 +36,7 @@ const useStyles = makeStyles(({ constants, zIndex, animation }: CSFTheme) => {
       bottom: styleProps?.bottom,
       right: styleProps?.right,
       zIndex: zIndex?.blocker,
-      visibility: "hidden",
-      opacity: 0,
-      transition: `opacity ${animation.transform * 2}ms`,
-      "&.open": {
-        visibility: "visible",
-        opacity: 1
-      }
+      transition: `opacity ${animation.transform * 2}ms`
     }),
     paper: {
       padding: `${constants.generalUnit}px 0`,
@@ -58,9 +53,9 @@ const useStyles = makeStyles(({ constants, zIndex, animation }: CSFTheme) => {
 const MENU_RIGHT_SPACE_TOLERANCE = 180
 const MENU_BOTTOM_SPACE_TOLERANCE = 250
 
-export default function MenuDropdown({ isOpen, options, anchorPosition, onClose }: Props) {
+export default function MenuDropdown({ options, anchorPosition, onClose }: Props) {
   const position = useMemo(() => {
-    if (!anchorPosition || !isOpen) return
+    if (!anchorPosition) return
 
     const windowHeight = window.innerHeight
     const windowWidth = window.innerWidth
@@ -78,26 +73,26 @@ export default function MenuDropdown({ isOpen, options, anchorPosition, onClose 
       position.right = windowWidth - anchorPosition.left
     }
     return position
-  }, [anchorPosition, isOpen])
+  }, [anchorPosition])
 
+  const onCloseMenu = useCallback(() => {
+    document.body.style.overflowY = "scroll"
+    onClose()
+  }, [onClose])
   const classes = useStyles(position)
 
   const ref = useRef<HTMLDivElement>(null)
-  useOnClickOutside(ref, onClose)
+  useOnClickOutside(ref, onCloseMenu)
 
   useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflowY = "hidden"
-    } else {
-      document.body.style.overflowY = "scroll"
-    }
-  }, [isOpen])
+    document.body.style.overflowY = "hidden"
+  }, [])
 
   if (!position) return null
 
   return (
     <div
-      className={clsx(classes.anchorRoot, "open")}
+      className={clsx(classes.anchorRoot)}
       ref={ref}
     >
       <Paper className={classes.paper}>

--- a/packages/storage-ui/src/Components/UI-components/AnchorMenu.tsx
+++ b/packages/storage-ui/src/Components/UI-components/AnchorMenu.tsx
@@ -1,8 +1,10 @@
-import React, {  ReactNode, useEffect, useMemo, useRef } from "react"
+import React, {  ReactNode, useCallback, useEffect, useMemo, useRef } from "react"
 import { MenuItem, Paper, PopoverPosition } from "@material-ui/core"
 import { makeStyles, createStyles, useOnClickOutside } from "@chainsafe/common-theme"
 import clsx from "clsx"
 import { CSSTheme } from "../../Themes/types"
+
+export type AnchoreMenuPosition = PopoverPosition;
 
 interface Option {
   contents: ReactNode
@@ -12,9 +14,8 @@ interface Option {
 }
 
 interface Props {
-  isOpen: boolean
   options: Option[]
-  anchorPosition?: PopoverPosition
+  anchorPosition?: AnchoreMenuPosition
   onClose: () => void
 }
 
@@ -35,13 +36,7 @@ const useStyles = makeStyles(({ constants, zIndex, animation }: CSSTheme) => {
       bottom: styleProps?.bottom,
       right: styleProps?.right,
       zIndex: zIndex?.blocker,
-      visibility: "hidden",
-      opacity: 0,
-      transition: `opacity ${animation.transform * 2}ms`,
-      "&.open": {
-        visibility: "visible",
-        opacity: 1
-      }
+      transition: `opacity ${animation.transform * 2}ms`
     }),
     paper: {
       padding: `${constants.generalUnit}px 0`,
@@ -58,9 +53,9 @@ const useStyles = makeStyles(({ constants, zIndex, animation }: CSSTheme) => {
 const MENU_RIGHT_SPACE_TOLERANCE = 180
 const MENU_BOTTOM_SPACE_TOLERANCE = 250
 
-export default function MenuDropdown({ isOpen, options, anchorPosition, onClose }: Props) {
+export default function MenuDropdown({ options, anchorPosition, onClose }: Props) {
   const position = useMemo(() => {
-    if (!anchorPosition || !isOpen) return
+    if (!anchorPosition) return
 
     const windowHeight = window.innerHeight
     const windowWidth = window.innerWidth
@@ -78,26 +73,26 @@ export default function MenuDropdown({ isOpen, options, anchorPosition, onClose 
       position.right = windowWidth - anchorPosition.left
     }
     return position
-  }, [anchorPosition, isOpen])
+  }, [anchorPosition])
 
+  const onCloseMenu = useCallback(() => {
+    document.body.style.overflowY = "scroll"
+    onClose()
+  }, [onClose])
   const classes = useStyles(position)
 
   const ref = useRef<HTMLDivElement>(null)
-  useOnClickOutside(ref, onClose)
+  useOnClickOutside(ref, onCloseMenu)
 
   useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflowY = "hidden"
-    } else {
-      document.body.style.overflowY = "scroll"
-    }
-  }, [isOpen])
+    document.body.style.overflowY = "hidden"
+  }, [])
 
   if (!position) return null
 
   return (
     <div
-      className={clsx(classes.anchorRoot, "open")}
+      className={clsx(classes.anchorRoot)}
       ref={ref}
     >
       <Paper className={classes.paper}>


### PR DESCRIPTION
I was still having issues despite my earlier suggestions, so I refactored a tiny bit and this time I can't reproduce any more.

This PR gets rid of the open/isOpen props and css. Unify the `anchorPosition` and `contextMenuPosition` which are the same.

How I could reproduce on Firefox before:
- refresh the page (with cache clean with ctrl+R)
- scroll
- right-click -> the first time it was flashing consistently.


 
