### PR TITLE
Error modal styles

### DIFF
--- a/packages/files-ui/src/Components/Modules/ErrorModal.tsx
+++ b/packages/files-ui/src/Components/Modules/ErrorModal.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React from "react"
 import { Button, Modal, Typography } from "@chainsafe/common-components"
 import { ROUTE_LINKS } from "../FilesRoutes"
@@ -14,7 +13,7 @@ const ErrorModal = ({ error, componentStack, resetError }: Props) => {
 
   const generalStyle = {
     margin: "1rem",
-    backgrounColor: "var(--gray1)",
+    backgroundColor: "var(--gray1)",
     color: "var(--gray9)"
   }
 
@@ -31,7 +30,7 @@ const ErrorModal = ({ error, componentStack, resetError }: Props) => {
         ...generalStyle
       }}
     >
-        An unexpected error occured
+        An unexpected error occurred
     </Typography>
     <Typography
       component="p"
@@ -45,7 +44,6 @@ const ErrorModal = ({ error, componentStack, resetError }: Props) => {
         Discord
       </a>
     </Typography>
-    <br/>
     <Typography
       variant="h4"
       style={{
@@ -61,11 +59,13 @@ const ErrorModal = ({ error, componentStack, resetError }: Props) => {
         backgroundColor: "ghostwhite",
         padding: "1rem",
         marginTop: 0,
-        color: "black"
+        color: "black",
+        maxHeight: "8rem",
+        overflow: "auto"
       }}
       component="p"
     >
-      <pre>{error?.message.toString()}</pre>
+      {error?.message.toString()}
     </Typography>
     <Typography
       variant="h4"
@@ -80,7 +80,7 @@ const ErrorModal = ({ error, componentStack, resetError }: Props) => {
       component="p"
       style={{
         ...generalStyle,
-        height: "5rem",
+        height: "10rem",
         overflow: "auto",
         padding: "1rem",
         border: "2px solid ghostwhite",


### PR DESCRIPTION
closes #2076 

To quickly check the changes,
we can add the error modal component in `app.tsx`
Here's a piece code to speed things up.

```
<ErrorModal
  error={new Error("Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.")}
  componentStack={"Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."}
  eventId='12'
  resetError={() => undefined}
/>
```
 
