### PR TITLE
Remove duplicate testid for dialog buttons

### DIFF
--- a/packages/common-components/src/Dialog/Dialog.tsx
+++ b/packages/common-components/src/Dialog/Dialog.tsx
@@ -84,6 +84,7 @@ const Dialog: React.FC<IDialogProps> = ({
           onClick={() => reject()}
           variant="dashed"
           size="medium"
+          testId={`reject-${testId}`}
           {...rejectButtonProps}
         >
           {rejectText}
@@ -92,6 +93,7 @@ const Dialog: React.FC<IDialogProps> = ({
           onClick={() => accept()}
           variant="primary"
           size="medium"
+          testId={`confirm-${testId}`}
           {...acceptButtonProps}
         >
           {acceptText}

--- a/packages/files-ui/cypress/support/page-objects/modals/deleteFileModal.ts
+++ b/packages/files-ui/cypress/support/page-objects/modals/deleteFileModal.ts
@@ -1,5 +1,5 @@
 export const deleteFileModal = {
   body: () => cy.get("[data-testid=modal-container-file-deletion]"),
-  cancelButton: () => cy.get("[data-testid=button-cancel-deletion]"),
-  confirmButton: () => cy.get("[data-testid=button-confirm-deletion]", { timeout: 10000 })
+  cancelButton: () => cy.get("[data-testid=button-reject-file-deletion]"),
+  confirmButton: () => cy.get("[data-testid=button-confirm-file-deletion]", { timeout: 10000 })
 }

--- a/packages/files-ui/cypress/support/page-objects/modals/deleteSharedFolderModal.ts
+++ b/packages/files-ui/cypress/support/page-objects/modals/deleteSharedFolderModal.ts
@@ -1,5 +1,5 @@
 export const deleteSharedFolderModal = {
   body: () => cy.get("[data-testid=modal-container-shared-folder-deletion]"),
-  cancelButton: () => cy.get("[data-testid=button-cancel-deletion]"),
-  confirmButton: () => cy.get("[data-testid=button-confirm-deletion]", { timeout: 10000 })
+  cancelButton: () => cy.get("[data-testid=button-reject-shared-folder-deletion]"),
+  confirmButton: () => cy.get("[data-testid=button-confirm-shared-folder-deletion]", { timeout: 10000 })
 }

--- a/packages/files-ui/cypress/support/page-objects/modals/leaveSharedFolderModal.ts
+++ b/packages/files-ui/cypress/support/page-objects/modals/leaveSharedFolderModal.ts
@@ -1,5 +1,5 @@
 export const leaveSharedFolderModal = {
   body: () => cy.get("[data-testid=modal-container-shared-folder-leave]"),
-  cancelButton: () => cy.get("[data-testid=button-cancel-deletion]"),
-  confirmButton: () => cy.get("[data-testid=button-confirm-deletion]", { timeout: 10000 })
+  cancelButton: () => cy.get("[data-testid=button-reject-shared-folder-leave]"),
+  confirmButton: () => cy.get("[data-testid=button-confirm-shared-folder-leave]", { timeout: 10000 })
 }

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/SharedFoldersOverview.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/SharedFoldersOverview.tsx
@@ -385,8 +385,8 @@ const SharedFolderOverview = () => {
         }
         rejectText = {t`Cancel`}
         acceptText = {t`Confirm`}
-        acceptButtonProps={{ loading: isDeletingSharedFolder, disabled: isDeletingSharedFolder, testId: "confirm-deletion" }}
-        rejectButtonProps={{ disabled: isDeletingSharedFolder, testId: "cancel-deletion" }}
+        acceptButtonProps={{ loading: isDeletingSharedFolder, disabled: isDeletingSharedFolder }}
+        rejectButtonProps={{ disabled: isDeletingSharedFolder }}
         injectedClass={{ inner: classes.confirmDeletionDialog }}
         testId={bucketToDelete?.permission === "owner"
           ? "shared-folder-deletion"

--- a/packages/files-ui/src/Components/Modules/FileBrowsers/views/FilesList.tsx
+++ b/packages/files-ui/src/Components/Modules/FileBrowsers/views/FilesList.tsx
@@ -1450,8 +1450,8 @@ const FilesList = ({ isShared = false }: Props) => {
         }
         rejectText={t`Cancel`}
         acceptText={t`Confirm`}
-        acceptButtonProps={{ loading: isDeletingFiles, disabled: isDeletingFiles, testId: "confirm-deletion" }}
-        rejectButtonProps={{ disabled: isDeletingFiles, testId: "cancel-deletion" }}
+        acceptButtonProps={{ loading: isDeletingFiles, disabled: isDeletingFiles }}
+        rejectButtonProps={{ disabled: isDeletingFiles }}
         injectedClass={{ inner: classes.confirmDeletionDialog }}
         onModalBodyClick={(e) => {
           e.preventDefault()

--- a/packages/storage-ui/cypress/support/page-objects/modals/deleteBucketModal.ts
+++ b/packages/storage-ui/cypress/support/page-objects/modals/deleteBucketModal.ts
@@ -1,5 +1,5 @@
 export const deleteBucketModal = {
   body: () => cy.get("[data-testid=modal-container-bucket-deletion]"),
-  cancelButton: () => cy.get("[data-testid=button-bucket-cancel-deletion]"),
-  confirmButton: () => cy.get("[data-testid=button-bucket-confirm-deletion]", { timeout: 10000 })
+  cancelButton: () => cy.get("[data-testid=button-reject-bucket-deletion]"),
+  confirmButton: () => cy.get("[data-testid=button-confirm-bucket-deletion]", { timeout: 10000 })
 }

--- a/packages/storage-ui/src/Components/Pages/BucketsPage.tsx
+++ b/packages/storage-ui/src/Components/Pages/BucketsPage.tsx
@@ -390,8 +390,8 @@ const BucketsPage = () => {
         requestMessage={t`You are about to delete bucket - ${bucketToRemove?.name}`}
         rejectText = {t`Cancel`}
         acceptText = {t`Delete`}
-        acceptButtonProps={{ loading: isRemovingBucket, disabled: isRemovingBucket, testId: "bucket-confirm-deletion" }}
-        rejectButtonProps={{ disabled: isRemovingBucket, testId: "bucket-cancel-deletion" }}
+        acceptButtonProps={{ loading: isRemovingBucket, disabled: isRemovingBucket }}
+        rejectButtonProps={{ disabled: isRemovingBucket }}
         testId={"bucket-deletion"}
       />
     </div>


### PR DESCRIPTION
Small refactor of our Dialog `testId` handling, removing some unnecessary duplicate identifiers.