### PR TITLE
Hide NFTs page by default

### DIFF
--- a/packages/storage-ui/src/Components/Layouts/AppNav.tsx
+++ b/packages/storage-ui/src/Components/Layouts/AppNav.tsx
@@ -18,7 +18,7 @@ import {
   useLocation,
   KeySvg,
   CreditCardOutlinedSvg,
-  FileWithImageSvg
+  // FileWithImageSvg
 } from "@chainsafe/common-components"
 import { ROUTE_LINKS } from "../StorageRoutes"
 import { Trans } from "@lingui/macro"
@@ -344,7 +344,7 @@ const AppNav: React.FC<IAppNav> = ({ navOpen, setNavOpen }: IAppNav) => {
                   <Trans>CIDs</Trans>
                 </Typography>
               </Link>
-              <Link
+              {/* <Link
                 data-cy="nfts-nav"
                 onClick={handleOnClick}
                 className={clsx(classes.navItem, classes.navItemIconStroke, appNavTab === "nfts" && "selected")}
@@ -356,7 +356,7 @@ const AppNav: React.FC<IAppNav> = ({ navOpen, setNavOpen }: IAppNav) => {
                 >
                   <Trans>NFTs</Trans>
                 </Typography>
-              </Link>
+              </Link> */}
               <Link
                 data-cy="api-keys-nav"
                 onClick={handleOnClick}

--- a/packages/storage-ui/src/Components/Layouts/AppNav.tsx
+++ b/packages/storage-ui/src/Components/Layouts/AppNav.tsx
@@ -17,7 +17,7 @@ import {
   PowerDownIcon,
   useLocation,
   KeySvg,
-  CreditCardOutlinedSvg,
+  CreditCardOutlinedSvg
   // FileWithImageSvg
 } from "@chainsafe/common-components"
 import { ROUTE_LINKS } from "../StorageRoutes"


### PR DESCRIPTION
Hid the NFT page from the nav bar - this is a temporary measure until the NFT code is ready for prime time. Pages for listing and creation are accessible if the url is entered manually.