### PR TITLE
allow for multiple api keys

### DIFF
--- a/packages/storage-ui/cypress/tests/api-keys-management.cy.ts
+++ b/packages/storage-ui/cypress/tests/api-keys-management.cy.ts
@@ -21,7 +21,6 @@ describe("Main Navigation", () => {
 
       // ensure new key modal is closed and api key button is not enabled
       newKeyModal.secretLabel().should("not.exist")
-      apiKeysPage.addApiKeyButton().should("not.be.enabled")
 
       // ensure key id and status are correct in the table
       cy.get<string>("@keyId").then((keyId) => {

--- a/packages/storage-ui/src/Components/Modules/ApiKeys.tsx
+++ b/packages/storage-ui/src/Components/Modules/ApiKeys.tsx
@@ -16,7 +16,8 @@ import {
   DeleteSvg,
   MoreIcon,
   CopyIcon,
-  Divider } from "@chainsafe/common-components"
+  Divider
+} from "@chainsafe/common-components"
 import { CSSTheme } from "../../Themes/types"
 import { Trans } from "@lingui/macro"
 import dayjs from "dayjs"
@@ -96,7 +97,7 @@ const useStyles = makeStyles(({ constants, breakpoints, animation, zIndex, palet
       color: constants.createFolder.color,
       [breakpoints.down("md")]: {
         bottom:
-        Number(constants?.mobileButtonHeight) + constants.generalUnit,
+          Number(constants?.mobileButtonHeight) + constants.generalUnit,
         borderTopLeftRadius: `${constants.generalUnit * 1.5}px`,
         borderTopRightRadius: `${constants.generalUnit * 1.5}px`,
         maxWidth: `${breakpoints.width("md")}px !important`
@@ -226,7 +227,6 @@ const ApiKeys = () => {
               onClick={createStorageAccessKey}
               variant="outline"
               size="large"
-              disabled={keys.filter(k => k.type === "storage").length > 0}
             >
               <PlusIcon />
               <span>


### PR DESCRIPTION
Removes limitation on generating multiple api keys from the UI, since this restriction has now been lifted on the API.